### PR TITLE
Conflict resolution

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -81,12 +81,9 @@
 #include "mongo/db/storage/storage_options.h"
 #include "mongo/db/storage/storage_parameters_gen.h"
 #include "mongo/db/storage/storage_repair_observer.h"
-<<<<<<< HEAD
 #include "mongo/db/storage/wiredtiger/encryption_keydb.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_backup_cursor_hooks.h"
-=======
 #include "mongo/db/storage/wiredtiger/wiredtiger_cache_pressure_monitor.h"
->>>>>>> bb63dd66dec
 #include "mongo/db/storage/wiredtiger/wiredtiger_connection.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_cursor.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_customization_hooks.h"

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
@@ -729,23 +729,11 @@ private:
         StorageEngine::DropIdentCallback callback;
     };
 
-<<<<<<< HEAD
     // srcPath, destPath, session, cursor
     typedef std::tuple<boost::filesystem::path, boost::filesystem::path, std::shared_ptr<WiredTigerSession>, WT_CURSOR*> DBTuple;
     // srcPath, destPath, filename, size to copy
     typedef std::tuple<boost::filesystem::path, boost::filesystem::path, boost::uintmax_t, std::time_t> FileTuple;
 
-    // Tracks the state of statistics relevant to cache pressure. These only make sense as deltas
-    // against the previous value.
-    struct CachePressureStats {
-        int64_t cacheWaitUsecs = 0;
-        int64_t txnsCommittedCount = 0;
-        // Record when the current stats were generated.
-        int64_t timestamp = 0;
-    };
-
-=======
->>>>>>> bb63dd66dec
     Status _createRecordStore(const NamespaceString& ns,
                               StringData ident,
                               KeyFormat keyFormat,


### PR DESCRIPTION
### Conflict in file `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h`:

**Ours**:
This patch introduces functionality related to **data-at-rest encryption and hot backups**.

Key changes include:
- **EncryptionKeyDB Integration**: A new `EncryptionKeyDB` class is introduced to manage encryption keys. The `WiredTigerKVEngine` now includes methods to get and interact with this component.
- **Data-at-Rest Encryption Class**: A new inner class, `DataAtRestEncryption`, is added to handle the core encryption logic.
- **Hot Backup Functionality**: New methods (`hotBackup`, `hotBackupTar`) are added to support creating hot backups of the database, including to S3 storage (`percona::S3BackupParameters`). This involves new helper types (`DBTuple`, `FileTuple`) for managing database files during the backup process.
- **Constructor Updates**: The `WiredTigerKVEngine` constructor is updated to accept a `PeriodicRunner` and a `MasterKeyProviderFactory`, which are necessary for managing encryption key states.
- **New Header Includes**: `master_key_provider.h` and `log_component.h` are included to support the new encryption and logging features.


<details>
<summary>Show diff</summary>

```
diff --git a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
index 85c4e474820..88bfc93a956 100644
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
@@ -34,6 +34,7 @@
 #include "mongo/base/string_data.h"
 #include "mongo/bson/bsonobj.h"
 #include "mongo/bson/timestamp.h"
+#include "mongo/db/encryption/master_key_provider.h"
 #include "mongo/db/namespace_string.h"
 #include "mongo/db/operation_context.h"
 #include "mongo/db/storage/journal_listener.h"
@@ -53,6 +54,7 @@
 #include "mongo/db/storage/wiredtiger/wiredtiger_size_storer.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_snapshot_manager.h"
 #include "mongo/db/tenant_id.h"
+#include "mongo/logv2/log_component.h"
 #include "mongo/platform/atomic.h"
 #include "mongo/platform/atomic_word.h"
 #include "mongo/stdx/condition_variable.h"
@@ -77,8 +79,8 @@
 #include <boost/optional/optional.hpp>
 
 namespace mongo {
-
 class ClockSource;
+class EncryptionKeyDB;
 class JournalListener;
 
 class WiredTigerConnection;
@@ -282,6 +284,10 @@ public:
      */
     virtual void sizeStorerPeriodicFlush() {}
 
+    virtual EncryptionKeyDB* getEncryptionKeyDB() noexcept {
+        return nullptr;
+    }
+
     /**
      * WiredTiger statistics cursors can be used if the WT connection is ready and it is not
      * shutting down or starting up. In that case, a tryGetStatsCollectionPermit call returns a
@@ -329,6 +335,11 @@ protected:
 // WiredTiger instance.
 class WiredTigerKVEngine final : public WiredTigerKVEngineBase {
 public:
+    /// @brief Constructor.
+    ///
+    /// @param periodicRuner pointer to a `PeriodicRunner`. Must be a valid
+    ///     pointer if both data-at-rest encryption and key state polling are
+    ///     enabled in `encryptionGlobalParams`.
     WiredTigerKVEngine(const std::string& canonicalName,
                        const std::string& path,
                        ClockSource* cs,
@@ -337,7 +348,10 @@ public:
                        bool repair,
                        bool isReplSet,
                        bool shouldRecoverFromOplogAsStandalone,
-                       bool inStandaloneMode);
+                       bool inStandaloneMode,
+                       PeriodicRunner* periodicRunner = nullptr,
+                       const encryption::MasterKeyProviderFactory& keyProviderFactory =
+                           encryption::MasterKeyProvider::create);
 
     ~WiredTigerKVEngine() override;
 
@@ -454,6 +468,8 @@ public:
 
     Status alterMetadata(StringData uri, StringData config) override;
 
+    void keydbDropDatabase(const DatabaseName& dbName) override;
+
     void flushAllFiles(OperationContext* opCtx, bool callerHoldsReadLock) override;
 
     Status beginBackup() override;
@@ -471,6 +487,10 @@ public:
 
     StatusWith<std::deque<std::string>> extendBackupCursor() override;
 
+    Status hotBackup(OperationContext* opCtx, const std::string& path) override;
+    Status hotBackupTar(OperationContext* opCtx, const std::string& path) override;
+    Status hotBackup(OperationContext* opCtx, const percona::S3BackupParameters& s3params) override;
+
     int64_t getIdentSize(RecoveryUnit&, StringData ident) override;
 
     Status repairIdent(RecoveryUnit& ru, StringData ident) override;
@@ -550,6 +570,12 @@ public:
 
     void syncSizeInfo(bool sync) const;
 
+    std::string getCanonicalName() const {
+        return _canonicalName;
+    }
+
+    EncryptionKeyDB* getEncryptionKeyDB() noexcept override;
+
     /*
      * Always returns a non-null pointer and is valid for the lifetime of this KVEngine. However,
      * the WiredTigerOplogManager may not have been initialized, which happens after the oplog
@@ -695,11 +721,18 @@ public:
     }
 
 private:
+    class DataAtRestEncryption;
+
     struct IdentToDrop {
         std::string uri;
         StorageEngine::DropIdentCallback callback;
     };
 
+    // srcPath, destPath, session, cursor
+    typedef std::tuple<boost::filesystem::path, boost::filesystem::path, std::shared_ptr<WiredTigerSession>, WT_CURSOR*> DBTuple;
+    // srcPath, destPath, filename, size to copy
+    typedef std::tuple<boost::filesystem::path, boost::filesystem::path, boost::uintmax_t, std::time_t> FileTuple;
+
     // Tracks the state of statistics relevant to cache pressure. These only make sense as deltas
     // against the previous value.
     struct CachePressureStats {
@@ -719,6 +752,15 @@ private:
 
     void _checkpoint(WiredTigerSession& session, bool useTimestamp);
 
+    Status _hotBackupPopulateLists(OperationContext* opCtx,
+                                   const std::string& path,
+                                   std::vector<DBTuple>& dbList,
+                                   std::vector<FileTuple>& filesList,
+                                   boost::uintmax_t& totalfsize);
+
+    // auxiliary function for beginNonBlockingBackup
+    StatusWith<std::unique_ptr<StorageEngine::StreamingCursor>> _disableIncrementalBackup();
+
     /**
      * Opens a connection on the WiredTiger database 'path' with the configuration 'wtOpenConfig'.
      * Only returns when successful. Initializes both '_conn' and '_fileVersion'.
@@ -796,6 +838,7 @@ private:
     StorageEngine::OldestActiveTransactionTimestampCallback
         _oldestActiveTransactionTimestampCallback;
 
+    std::unique_ptr<DataAtRestEncryption> _restEncr;
     WiredTigerFileVersion _fileVersion;
 
     const std::unique_ptr<WiredTigerOplogManager> _oplogManager;
@@ -866,6 +909,9 @@ private:
     // A long-lived session for ensuring data is periodically flushed to disk.
     std::unique_ptr<WiredTigerSession> _waitUntilDurableSession = nullptr;
 
+    // keyDB analog of _waitUntilDurableSession
+    WT_SESSION* _keyDBSession = nullptr;
+
     // Tracks the time since the last _waitUntilDurableSession reset().
     Timer _timeSinceLastDurabilitySessionReset;

```
</details>

**Theirs**
This patch focuses on **refactoring cache pressure management**.

Key changes include:
- **CachePressureMonitor**: A new `WiredTigerCachePressureMonitor` class is introduced to encapsulate the logic for monitoring and managing cache pressure. An instance of this monitor is added to the `WiredTigerKVEngine`.
- **Removal of Direct Cache Logic**: The `CachePressureStats` struct and related logic for tracking cache wait times, transaction counts, and tickets (`_lastStats`, `_totalTicketsEDMA`) are removed from `WiredTigerKVEngine`.
- **Method Removal**: Helper methods previously responsible for cache pressure calculations (`_windowTrackingStorageAppWaitTimeAndWriteLoad`, `_storageCacheRatioReachesEvictionTrigger`) are removed, as their functionality has been moved into the new monitor class.

<details>
<summary>Show diff</summary>

```
diff --git a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
index 85c4e474820..9f41c33b11a 100644
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
@@ -44,6 +44,7 @@
 #include "mongo/db/storage/snapshot_manager.h"
 #include "mongo/db/storage/sorted_data_interface.h"
 #include "mongo/db/storage/storage_engine.h"
+#include "mongo/db/storage/wiredtiger/wiredtiger_cache_pressure_monitor.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_connection.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_event_handler.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_extensions.h"
@@ -700,15 +701,6 @@ private:
         StorageEngine::DropIdentCallback callback;
     };
 
-    // Tracks the state of statistics relevant to cache pressure. These only make sense as deltas
-    // against the previous value.
-    struct CachePressureStats {
-        int64_t cacheWaitUsecs = 0;
-        int64_t txnsCommittedCount = 0;
-        // Record when the current stats were generated.
-        int64_t timestamp = 0;
-    };
-
     Status _createRecordStore(const NamespaceString& ns,
                               StringData ident,
                               KeyFormat keyFormat,
@@ -786,12 +778,6 @@ private:
     // Wrapped method call to WT_SESSION::drop that handles sub-level error codes if applicable.
     Status _drop(WiredTigerSession& session, const char* uri, const char* config);
 
-    bool _windowTrackingStorageAppWaitTimeAndWriteLoad(WiredTigerSession& session,
-                                                       int concurrentWriteOuts,
-                                                       int concurrentReadOuts);
-
-    bool _storageCacheRatioReachesEvictionTrigger(WiredTigerSession& session);
-
     mutable stdx::mutex _oldestActiveTransactionTimestampCallbackMutex;
     StorageEngine::OldestActiveTransactionTimestampCallback
         _oldestActiveTransactionTimestampCallback;
@@ -809,6 +795,8 @@ private:
 
     std::unique_ptr<WiredTigerSessionSweeper> _sessionSweeper;
 
+    std::unique_ptr<WiredTigerCachePressureMonitor> _cachePressureMonitor;
+
     std::string _indexOptions;
 
     std::unique_ptr<WiredTigerSession> _backupSession;
@@ -869,17 +857,6 @@ private:
     // Tracks the time since the last _waitUntilDurableSession reset().
     Timer _timeSinceLastDurabilitySessionReset;
 
-    // Record the stats for use in calculating deltas between calls to underCachePressure().
-    CachePressureStats _lastStats;
-
-    // Tracks the last time we saw the cache pressure result for thread pressure was not exceeded.
-    Date_t _lastGoodputObservedTimestamp;
-
-    // Since we are tracking the total tickets over a duration, and the tickets we hold are an
-    // instantaneous value, we will use an exponentially decaying moving average to smooth out
-    // noise and avoid aggressive short-term over-corrections due to short-term changes.
-    double _totalTicketsEDMA = 1.0;  // Setting a default value.
-
     // Prevents a database's directory from being deleted concurrently with creation (necessary for
     // --directoryPerDb).
     stdx::mutex _directoryModificationMutex;

```
</details>