### PR TITLE
Conflict resolution

### DIFF
--- a/bazel/config/BUILD.bazel
+++ b/bazel/config/BUILD.bazel
@@ -8,12 +8,9 @@ load(
     "//bazel/config:configs.bzl",
     "allocator",
     "asan",
-<<<<<<< HEAD
     "audit",
-=======
     "bolt_profile_generate",
     "bolt_profile_use",
->>>>>>> baef5f2220a
     "build_enterprise",
     "build_otel",
     "compiler_type",


### PR DESCRIPTION
# Conflict Resolution Explanation

This document explains the resolution of a merge conflict in `bazel/config/BUILD.bazel`.

## `bazel/config/BUILD.bazel`

The merge conflict in this file was due to two branches adding new build configurations simultaneously.

- **Our changes** introduced several new boolean flags for enterprise features like `inmemory`, `audit`, `full-featured`, `fipsmode`, `fcbis`, and `oidc`.
- **Their changes** focused on refactoring and adding profile-guided optimization (PGO) and Link Time Optimization (LTO) flags, such as `pgo_profile_generate`, `pgo_profile_use`, `bolt_profile_generate`, and `propeller_profile_use`.

The conflict was resolved as follows:

1.  **`load()` statement**: The list of imported symbols in the `load()` statement from `//bazel/config:configs.bzl` was merged. Symbols from both branches were combined and then sorted alphabetically to maintain code style. The `pgo_profile` symbol was correctly replaced by `pgo_profile_generate` and `pgo_profile_use` as part of the refactoring in their branch.

2.  **Configuration Blocks**: The new configuration blocks from both branches were independent and did not have overlapping logic. I preserved the blocks from both changes in the final merged file. "Our" changes were added before the `thin_lto` section, and "their" changes, which refactored the `pgo_profile` section, were applied in place.

The final merged file incorporates all new features and improvements from both branches while maintaining the project's structure and coding standards.

# Merge Conflict Resolution Prompt

You are helping to resolve merge conflicts in a Git repository. Below are the conflicts that need to be resolved.


## Conflict in `bazel/config/BUILD.bazel`

### Our Changes (from common ancestor)

<details>
<summary>Show diff</summary>

```diff
diff --git a/b95041e8a6f01afbf2f4d0492dc569a92c6ac042 b/899994cd8453bf190e3e8258ee6f7d54a5c3a1a4
index b95041e8a6f..899994cd845 100644
--- a/b95041e8a6f01afbf2f4d0492dc569a92c6ac042
+++ b/899994cd8453bf190e3e8258ee6f7d54a5c3a1a4
@@ -8,6 +8,7 @@ load(
     "//bazel/config:configs.bzl",
     "allocator",
     "asan",
+    "audit",
     "build_enterprise",
     "build_otel",
     "compiler_type",
@@ -20,11 +21,15 @@ load(
     "disable_streams",
     "disable_warnings_as_errors",
     "dwarf_version",
+    "fcbis",
+    "fipsmode",
     "fsan",
+    "full_featured",
     "gcov",
     "http_client",
     "include_autogenerated_targets",
     "include_mongot",
+    "inmemory",
     "js_engine",
     "libunwind",
     "linker",
@@ -32,6 +37,7 @@ load(
     "lsan",
     "mongo_toolchain_version",
     "msan",
+    "oidc",
     "opt",
     "pgo_profile",
     "release",
@@ -2190,6 +2196,144 @@ selects.config_setting_group(
     ],
 )
 
+# --------------------------------------
+# inmemory
+# --------------------------------------
+
+inmemory(
+    name = "inmemory",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "inmemory_enabled",
+    flag_values = {
+        "//bazel/config:inmemory": "True",
+    },
+)
+
+config_setting(
+    name = "inmemory_disabled",
+    flag_values = {
+        "//bazel/config:inmemory": "False",
+    },
+)
+
+# --------------------------------------
+# audit
+# --------------------------------------
+
+audit(
+    name = "audit",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "audit_enabled",
+    flag_values = {
+        "//bazel/config:audit": "True",
+    },
+)
+
+config_setting(
+    name = "audit_disabled",
+    flag_values = {
+        "//bazel/config:audit": "False",
+    },
+)
+
+# --------------------------------------
+# full-featured
+# --------------------------------------
+
+full_featured(
+    name = "full-featured",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "full_featured_enabled",
+    flag_values = {
+        "//bazel/config:full-featured": "True",
+    },
+)
+
+config_setting(
+    name = "full_featured_disabled",
+    flag_values = {
+        "//bazel/config:full-featured": "False",
+    },
+)
+
+# --------------------------------------
+# fipsmode
+# --------------------------------------
+
+fipsmode(
+    name = "enable-fipsmode",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "fipsmode_enabled",
+    flag_values = {
+        "//bazel/config:enable-fipsmode": "True",
+    },
+)
+
+config_setting(
+    name = "fipsmode_disabled",
+    flag_values = {
+        "//bazel/config:enable-fipsmode": "False",
+    },
+)
+
+# --------------------------------------
+# fcbis
+# --------------------------------------
+
+fcbis(
+    name = "enable-fcbis",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "fcbis_enabled",
+    flag_values = {
+        "//bazel/config:enable-fcbis": "True",
+    },
+)
+
+config_setting(
+    name = "fcbis_disabled",
+    flag_values = {
+        "//bazel/config:enable-fcbis": "False",
+    },
+)
+
+# --------------------------------------
+# OIDC
+# --------------------------------------
+
+oidc(
+    name = "enable-oidc",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "oidc_enabled",
+    flag_values = {
+        "//bazel/config:enable-oidc": "True",
+    },
+)
+
+config_setting(
+    name = "oidc_disabled",
+    flag_values = {
+        "//bazel/config:enable-oidc": "False",
+    },
+)
+
 # --------------------------------------
 # thin_lto
 # --------------------------------------
```

</details>

### Their Changes (from common ancestor)

<details>
<summary>Show diff</summary>

```diff
diff --git a/b95041e8a6f01afbf2f4d0492dc569a92c6ac042 b/2a2383c3f3f6bb664dd26dfc7326d12952c0d31c
index b95041e8a6f..2a2383c3f3f 100644
--- a/b95041e8a6f01afbf2f4d0492dc569a92c6ac042
+++ b/2a2383c3f3f6bb664dd26dfc7326d12952c0d31c
@@ -8,6 +8,8 @@ load(
     "//bazel/config:configs.bzl",
     "allocator",
     "asan",
+    "bolt_profile_generate",
+    "bolt_profile_use",
     "build_enterprise",
     "build_otel",
     "compiler_type",
@@ -33,7 +35,10 @@ load(
     "mongo_toolchain_version",
     "msan",
     "opt",
-    "pgo_profile",
+    "pgo_profile_generate",
+    "pgo_profile_use",
+    "propeller_profile_generate",
+    "propeller_profile_use",
     "release",
     "sdkroot",
     "separate_debug",
@@ -2223,30 +2228,130 @@ config_setting(
 )
 
 # --------------------------------------
-# pgo_profile options
+# pgo_profile_generate options
 # --------------------------------------
 
-pgo_profile(
-    name = "pgo_profile",
+pgo_profile_generate(
+    name = "pgo_profile_generate",
     build_setting_default = False,
 )
 
 config_setting(
-    name = "pgo_profile_enabled",
+    name = "pgo_profile_generate_enabled",
     flag_values = {
-        "//bazel/config:pgo_profile": "True",
+        "//bazel/config:pgo_profile_generate": "True",
     },
 )
 
+selects.config_setting_group(
+    name = "pgo_profile_generate_clang_enabled",
+    match_all = [
+        ":linux_clang",
+        ":pgo_profile_generate_enabled",
+    ],
+)
+
+selects.config_setting_group(
+    name = "pgo_profile_generate_gcc_enabled",
+    match_all = [
+        ":linux_gcc",
+        ":pgo_profile_generate_enabled",
+    ],
+)
+
+# --------------------------------------
+# pgo_profile_use options
+# --------------------------------------
+
+pgo_profile_use(
+    name = "pgo_profile_use",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "pgo_profile_use_enabled",
+    flag_values = {
+        "//bazel/config:pgo_profile_use": "True",
+    },
+)
+
+selects.config_setting_group(
+    name = "pgo_profile_use_clang_enabled",
+    match_all = [
+        ":linux_clang",
+        ":pgo_profile_use_enabled",
+    ],
+)
+
+selects.config_setting_group(
+    name = "pgo_profile_use_gcc_enabled",
+    match_all = [
+        ":linux_gcc",
+        ":pgo_profile_use_enabled",
+    ],
+)
+
+# --------------------------------------
+# bolt_profile_generate options
+# --------------------------------------
+
+bool_flag(
+    name = "bolt_profile_generate",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "bolt_profile_generate_enabled",
+    flag_values = {
+        "//bazel/config:bolt_profile_generate": "True",
+    },
+)
+
+# --------------------------------------
+# bolt_profile_use options
+# --------------------------------------
+
+bool_flag(
+    name = "bolt_profile_use",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "bolt_profile_use_enabled",
+    flag_values = {
+        "//bazel/config:bolt_profile_use": "True",
+    },
+)
+
+# --------------------------------------
+# propeller_profile_generate options
+# --------------------------------------
+
+bool_flag(
+    name = "propeller_profile_generate",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "propeller_profile_generate_enabled",
+    flag_values = {
+        "//bazel/config:propeller_profile_generate": "True",
+    },
+)
+
+# --------------------------------------
+# propeller_profile_use options
+# --------------------------------------
+
 bool_flag(
-    name = "bolt",
+    name = "propeller_profile_use",
     build_setting_default = False,
 )
 
 config_setting(
-    name = "bolt_enabled",
+    name = "propeller_profile_use_enabled",
     flag_values = {
-        "//bazel/config:bolt": "True",
+        "//bazel/config:propeller_profile_use": "True",
     },
 )
 
```

</details>


Please provide a resolution that:
- Incorporates the best aspects of both changes
- Maintains code quality and consistency
- Follows the project's coding standards

Please resolve the conflicts and provide the final merged version of each file.
Please provide an explanation of the changes you made to each file in an output markdown file named `conflict_resolution.md`.
