### PR TITLE
Conflict resolution

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
@@ -284,10 +284,10 @@ public:
      */
     virtual void sizeStorerPeriodicFlush() {}
 
-<<<<<<< HEAD
     virtual EncryptionKeyDB* getEncryptionKeyDB() noexcept {
         return nullptr;
-=======
+    }
+
     /**
      * WiredTiger statistics cursors can be used if the WT connection is ready and it is not
      * shutting down or starting up. In that case, a tryGetStatsCollectionPermit call returns a
@@ -303,7 +303,6 @@ public:
             return permit;
         }
         return boost::none;
->>>>>>> 97a2eb67e10
     }
 
 protected:


### PR DESCRIPTION
# Merge Conflict Resolution Report

## `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h`

### Conflict Description

The merge conflict in this file arose from two concurrent development efforts:
1.  **Our Changes (`main` branch):** A feature branch introduced significant additions for data-at-rest encryption and hot backup capabilities. This included new headers, new member functions (`getEncryptionKeyDB`, `hotBackup`, etc.), a new constructor for `WiredTigerKVEngine`, and several new private member variables to manage encryption and backup state.
2.  **Their Changes (`development` branch):** A separate branch performed a refactoring task. It moved the `tryGetStatsCollectionPermit()` method from the derived class `WiredTigerKVEngine` to its base class `WiredTigerKVEngineBase` to improve code structure and reuse. It also updated the signature of the `getWiredTigerConfigFromStartupOptions()` function, removing an obsolete parameter.

The conflict occurred specifically in the `WiredTigerKVEngineBase` class definition, where both branches attempted to add new methods in the same location.

### Resolution Strategy

My resolution strategy was to merge the changes logically, preserving the intent of both branches to create a coherent and correct final version of the file.

1.  **Combine Methods in `WiredTigerKVEngineBase`:** In the `WiredTigerKVEngineBase` class, I included both the new `getEncryptionKeyDB()` method (from our changes) and the moved `tryGetStatsCollectionPermit()` method (from their changes). This ensures that the base class contains all the intended functionality from both development branches.

2.  **Integrate All Feature Additions:** I incorporated all other non-conflicting additions from the encryption and backup feature branch. This includes new header includes, method overrides, and private member variables in the `WiredTigerKVEngine` class.

3.  **Preserve Refactoring Changes:** I honored the refactoring work by ensuring the `tryGetStatsCollectionPermit()` method was removed from `WiredTigerKVEngine` (as it now resides in the base class) and by adopting the updated, cleaner function signature for `getWiredTigerConfigFromStartupOptions()`.

By combining these changes, the final merged file now includes the new encryption/backup feature set as well as the beneficial code refactoring, resulting in a functionally complete and improved source file.

# Merge Conflict Resolution Prompt

You are helping to resolve merge conflicts in a Git repository. Below are the conflicts that need to be resolved.


## Conflict in `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h`

### Our Changes (from common ancestor)

<details>
<summary>Show diff</summary>

```diff
diff --git a/06dfd6eb1dc7c784cac910c3f119baabe4bfe6bf b/9f5880c74f4adfdcb51c70bfb8b9a346c1c109dd
index 06dfd6eb1dc..9f5880c74f4 100644
--- a/06dfd6eb1dc7c784cac910c3f119baabe4bfe6bf
+++ b/9f5880c74f4adfdcb51c70bfb8b9a346c1c109dd
@@ -34,6 +34,7 @@
 #include "mongo/base/string_data.h"
 #include "mongo/bson/bsonobj.h"
 #include "mongo/bson/timestamp.h"
+#include "mongo/db/encryption/master_key_provider.h"
 #include "mongo/db/namespace_string.h"
 #include "mongo/db/operation_context.h"
 #include "mongo/db/storage/journal_listener.h"
@@ -53,6 +54,7 @@
 #include "mongo/db/storage/wiredtiger/wiredtiger_size_storer.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_snapshot_manager.h"
 #include "mongo/db/tenant_id.h"
+#include "mongo/logv2/log_component.h"
 #include "mongo/platform/atomic.h"
 #include "mongo/platform/atomic_word.h"
 #include "mongo/stdx/condition_variable.h"
@@ -77,8 +79,8 @@
 #include <boost/optional/optional.hpp>
 
 namespace mongo {
-
 class ClockSource;
+class EncryptionKeyDB;
 class JournalListener;
 
 class WiredTigerConnection;
@@ -282,6 +284,10 @@ public:
      */
     virtual void sizeStorerPeriodicFlush() {}
 
+    virtual EncryptionKeyDB* getEncryptionKeyDB() noexcept {
+        return nullptr;
+    }
+
 protected:
     /**
      * Returns true if the given table uri exists in this WiredTiger instance.
@@ -312,6 +318,11 @@ protected:
 // WiredTiger instance.
 class WiredTigerKVEngine final : public WiredTigerKVEngineBase {
 public:
+    /// @brief Constructor.
+    ///
+    /// @param periodicRuner pointer to a `PeriodicRunner`. Must be a valid
+    ///     pointer if both data-at-rest encryption and key state polling are
+    ///     enabled in `encryptionGlobalParams`.
     WiredTigerKVEngine(const std::string& canonicalName,
                        const std::string& path,
                        ClockSource* cs,
@@ -320,7 +331,10 @@ public:
                        bool repair,
                        bool isReplSet,
                        bool shouldRecoverFromOplogAsStandalone,
-                       bool inStandaloneMode);
+                       bool inStandaloneMode,
+                       PeriodicRunner* periodicRunner = nullptr,
+                       const encryption::MasterKeyProviderFactory& keyProviderFactory =
+                           encryption::MasterKeyProvider::create);
 
     ~WiredTigerKVEngine() override;
 
@@ -437,6 +451,8 @@ public:
 
     Status alterMetadata(StringData uri, StringData config) override;
 
+    void keydbDropDatabase(const DatabaseName& dbName) override;
+
     void flushAllFiles(OperationContext* opCtx, bool callerHoldsReadLock) override;
 
     Status beginBackup() override;
@@ -454,6 +470,10 @@ public:
 
     StatusWith<std::deque<std::string>> extendBackupCursor() override;
 
+    Status hotBackup(OperationContext* opCtx, const std::string& path) override;
+    Status hotBackupTar(OperationContext* opCtx, const std::string& path) override;
+    Status hotBackup(OperationContext* opCtx, const percona::S3BackupParameters& s3params) override;
+
     int64_t getIdentSize(RecoveryUnit&, StringData ident) override;
 
     Status repairIdent(RecoveryUnit& ru, StringData ident) override;
@@ -533,6 +553,12 @@ public:
 
     void syncSizeInfo(bool sync) const;
 
+    std::string getCanonicalName() const {
+        return _canonicalName;
+    }
+
+    EncryptionKeyDB* getEncryptionKeyDB() noexcept override;
+
     /*
      * Always returns a non-null pointer and is valid for the lifetime of this KVEngine. However,
      * the WiredTigerOplogManager may not have been initialized, which happens after the oplog
@@ -695,11 +721,18 @@ public:
     }
 
 private:
+    class DataAtRestEncryption;
+
     struct IdentToDrop {
         std::string uri;
         StorageEngine::DropIdentCallback callback;
     };
 
+    // srcPath, destPath, session, cursor
+    typedef std::tuple<boost::filesystem::path, boost::filesystem::path, std::shared_ptr<WiredTigerSession>, WT_CURSOR*> DBTuple;
+    // srcPath, destPath, filename, size to copy
+    typedef std::tuple<boost::filesystem::path, boost::filesystem::path, boost::uintmax_t, std::time_t> FileTuple;
+
     // Tracks the state of statistics relevant to cache pressure. These only make sense as deltas
     // against the previous value.
     struct CachePressureStats {
@@ -719,6 +752,15 @@ private:
 
     void _checkpoint(WiredTigerSession& session, bool useTimestamp);
 
+    Status _hotBackupPopulateLists(OperationContext* opCtx,
+                                   const std::string& path,
+                                   std::vector<DBTuple>& dbList,
+                                   std::vector<FileTuple>& filesList,
+                                   boost::uintmax_t& totalfsize);
+
+    // auxiliary function for beginNonBlockingBackup
+    StatusWith<std::unique_ptr<StorageEngine::StreamingCursor>> _disableIncrementalBackup();
+
     /**
      * Opens a connection on the WiredTiger database 'path' with the configuration 'wtOpenConfig'.
      * Only returns when successful. Initializes both '_conn' and '_fileVersion'.
@@ -796,6 +838,7 @@ private:
     StorageEngine::OldestActiveTransactionTimestampCallback
         _oldestActiveTransactionTimestampCallback;
 
+    std::unique_ptr<DataAtRestEncryption> _restEncr;
     WiredTigerFileVersion _fileVersion;
 
     const std::unique_ptr<WiredTigerOplogManager> _oplogManager;
@@ -866,6 +909,9 @@ private:
     // A long-lived session for ensuring data is periodically flushed to disk.
     std::unique_ptr<WiredTigerSession> _waitUntilDurableSession = nullptr;
 
+    // keyDB analog of _waitUntilDurableSession
+    WT_SESSION* _keyDBSession = nullptr;
+
     // Tracks the time since the last _waitUntilDurableSession reset().
     Timer _timeSinceLastDurabilitySessionReset;
 
```

</details>


### Their Changes (from common ancestor)

<details>
<summary>Show diff</summary>

```diff
diff --git a/06dfd6eb1dc7c784cac910c3f119baabe4bfe6bf b/c4010318ea97917e7f6ff2b5b18dc738b5d2a1c5
index 06dfd6eb1dc..c4010318ea9 100644
--- a/06dfd6eb1dc7c784cac910c3f119baabe4bfe6bf
+++ b/c4010318ea97917e7f6ff2b5b18dc738b5d2a1c5
@@ -282,6 +282,23 @@ public:
      */
     virtual void sizeStorerPeriodicFlush() {}
 
+    /**
+     * WiredTiger statistics cursors can be used if the WT connection is ready and it is not
+     * shutting down or starting up. In that case, a tryGetStatsCollectionPermit call returns a
+     * StatsCollectionPermit object indicating that the caller may safely open statistics cursors,
+     * but the storage engine shutdown will be prevented from invalidating the underlying WT
+     * connection until the caller is done. When the WT connection is not ready, a
+     * tryGetStatsCollectionPermit call returns boost::none. ~StatsCollectionPermit releases the
+     * permit.
+     */
+    boost::optional<StatsCollectionPermit> tryGetStatsCollectionPermit() {
+        StatsCollectionPermit permit(&_eventHandler);
+        if (permit.conn()) {
+            return permit;
+        }
+        return boost::none;
+    }
+
 protected:
     /**
      * Returns true if the given table uri exists in this WiredTiger instance.
@@ -659,23 +676,6 @@ public:
 
     void sizeStorerPeriodicFlush() override;
 
-    /**
-     * WiredTiger statistics cursors can be used if the WT connection is ready and it is not
-     * shutting down or starting up. In that case, a tryGetStatsCollectionPermit call returns a
-     * StatsCollectionPermit object indicating that the caller may safely open statistics cursors,
-     * but the storage engine shutdown will be prevented from invalidating the underlying WT
-     * connection until the caller is done. When the WT connection is not ready, a
-     * tryGetStatsCollectionPermit call returns boost::none. ~StatsCollectionPermit releases the
-     * permit.
-     */
-    boost::optional<StatsCollectionPermit> tryGetStatsCollectionPermit() {
-        StatsCollectionPermit permit(&_eventHandler);
-        if (permit.conn()) {
-            return permit;
-        }
-        return boost::none;
-    }
-
     /**
      * Returns the number of active statistics readers that are blocking shutdown.
      */
@@ -900,7 +900,6 @@ std::string generateWTOpenConfigString(const WiredTigerKVEngineBase::WiredTigerC
  * Returns a WiredTigerKVEngineBase::WiredTigerConfig populated with config values provided at
  * startup.
  */
-WiredTigerKVEngineBase::WiredTigerConfig getWiredTigerConfigFromStartupOptions(
-    bool usingSpillWiredTigerKVEngine = false);
+WiredTigerKVEngineBase::WiredTigerConfig getWiredTigerConfigFromStartupOptions();
 
 }  // namespace mongo
```

</details>


Please provide a resolution that:
- Incorporates the best aspects of both changes
- Maintains code quality and consistency
- Follows the project's coding standards
- Does not make any changes to the file that are not related to the conflict

Please resolve the conflicts and provide the final merged version of each file.
Please provide an explanation of the changes you made to each file in an output markdown file named `conflict_resolution.md`.
