### PR TITLE
Conflict solution

### DIFF
--- a/jstests/sharding/database_versioning_all_commands.js
+++ b/jstests/sharding/database_versioning_all_commands.js
@@ -866,65 +866,10 @@ const allTestCases = {
         },
         waitForFailPoint: {skip: "executes locally on mongos (not sent to any remote node)"},
         whatsmyuri: {skip: "executes locally on mongos (not sent to any remote node)"},
-    },
-<<<<<<< HEAD
-    updateRole: {skip: "always targets the config server"},
-    updateSearchIndex: {skip: "executes locally on mongos", conditional: true},
-    updateUser: {skip: "always targets the config server"},
-    updateZoneKeyRange: {skip: "not on a user database"},
-    usersInfo: {skip: "always targets the config server"},
-    validate: {
-        run: {
-            sendsDbVersion: true,
-            explicitlyCreateCollection: true,
-            command: function(dbName, collName) {
-                return {validate: collName};
-            },
-        }
-    },
-    validateDBMetadata: {
-        run: {
-            // validateDBMetadata is always broadcast to all shards.
-            sendsDbVersion: false,
-            explicitlyCreateCollection: true,
-            command: function(dbName, collName) {
-                return {validateDBMetadata: 1, apiParameters: {version: "1"}};
-            },
-        }
-    },
-    waitForFailPoint: {skip: "executes locally on mongos (not sent to any remote node)"},
-    whatsmyuri: {skip: "executes locally on mongos (not sent to any remote node)"},
 
-    // Percona commands
-    auditGetOptions: {skip: "executes locally on mongos (not sent to any remote node)"},
-||||||| 97867d5d209
-    updateRole: {skip: "always targets the config server"},
-    updateSearchIndex: {skip: "executes locally on mongos", conditional: true},
-    updateUser: {skip: "always targets the config server"},
-    updateZoneKeyRange: {skip: "not on a user database"},
-    usersInfo: {skip: "always targets the config server"},
-    validate: {
-        run: {
-            sendsDbVersion: true,
-            explicitlyCreateCollection: true,
-            command: function(dbName, collName) {
-                return {validate: collName};
-            },
-        }
+        // Percona commands
+        auditGetOptions: {skip: "executes locally on mongos (not sent to any remote node)"},
     },
-    validateDBMetadata: {
-        run: {
-            // validateDBMetadata is always broadcast to all shards.
-            sendsDbVersion: false,
-            explicitlyCreateCollection: true,
-            command: function(dbName, collName) {
-                return {validateDBMetadata: 1, apiParameters: {version: "1"}};
-            },
-        }
-    },
-    waitForFailPoint: {skip: "executes locally on mongos (not sent to any remote node)"},
-    whatsmyuri: {skip: "executes locally on mongos (not sent to any remote node)"},
-=======
     mongod: {
         _addShard: {skip: "not on a user database"},
         _configsvrAbortReshardCollection: {skip: "TODO"},
@@ -1228,7 +1173,7 @@ const allTestCases = {
         renameCollection: {skip: "TODO"},
         replSetAbortPrimaryCatchUp: {skip: "TODO"},
         replSetFreeze: {skip: "TODO"},
-        replSetGetConfig: {skip: "TODO"},
+        replSetGetConfig:.
         replSetGetRBID: {skip: "TODO"},
         replSetGetStatus: {skip: "TODO"},
         replSetHeartbeat: {skip: "TODO"},
@@ -1310,7 +1255,6 @@ const allTestCases = {
         whatsmysni: {skip: "TODO"},
         whatsmyuri: {skip: "TODO"},
     }
->>>>>>> 5bc2052b2c1
 };
 
 // TODO (SERVER-101777): This test makes a lot of assumptions about database versions stored in

--- a/jstests/sharding/database_versioning_all_commands.js
+++ b/jstests/sharding/database_versioning_all_commands.js
@@ -1173,7 +1173,7 @@ const allTestCases = {
         renameCollection: {skip: "TODO"},
         replSetAbortPrimaryCatchUp: {skip: "TODO"},
         replSetFreeze: {skip: "TODO"},
-        replSetGetConfig:.
+        replSetGetConfig: {skip: "TODO"},
         replSetGetRBID: {skip: "TODO"},
         replSetGetStatus: {skip: "TODO"},
         replSetHeartbeat: {skip: "TODO"},
@@ -1254,7 +1254,10 @@ const allTestCases = {
         waitForFailPoint: {skip: "TODO", conditional: true},
         whatsmysni: {skip: "TODO"},
         whatsmyuri: {skip: "TODO"},
-    }
+
+        // Percona commands
+        auditGetOptions: {skip: "executes locally on mongos (not sent to any remote node)"},
+    },
 };
 
 // TODO (SERVER-101777): This test makes a lot of assumptions about database versions stored in

--- a/src/mongo/config.h.in
+++ b/src/mongo/config.h.in
@@ -124,13 +124,10 @@
 
 // Defined if the build includes OpenTelemetry
 @mongo_config_otel@
-<<<<<<< HEAD
 
 // Defined if basic_stringbuf::str()&& overload exists
 @mongo_config_have_basic_stringbuf_str_rvalue@
-||||||| 97867d5d209
-=======
 
 // Defined if the build includes mutex observation
 @mongo_config_mutex_observation@
->>>>>>> 5bc2052b2c1
+

--- a/src/mongo/executor/BUILD.bazel
+++ b/src/mongo/executor/BUILD.bazel
@@ -511,13 +511,9 @@ mongo_cc_library(
         ":task_executor_interface",
         "//src/mongo:base",
         "//src/mongo/db:query_expressions",
-<<<<<<< HEAD
         "//src/mongo/db/audit:audit_impl",
         "//src/mongo/db/audit:audit_options",
-||||||| 97867d5d209
-=======
         "//src/mongo/db:query_matcher",
->>>>>>> 5bc2052b2c1
         "//src/mongo/rpc:metadata",
         "//src/mongo/util:clock_source_mock",
         "//src/mongo/util/net:network",

--- a/src/mongo/shell/mongo.js
+++ b/src/mongo/shell/mongo.js
@@ -398,16 +398,8 @@ globalThis.connect = function(url, user, pass, apiParameters) {
     TestData = Object.merge(originalTestData, {disableImplicitSessions: true});
     try {
         // Check server version
-<<<<<<< HEAD
-        var serverVersion = db.version();
-        chatty("Percona Server for MongoDB server version: v" + serverVersion);
-||||||| 97867d5d209
-        var serverVersion = db.version();
-        chatty("MongoDB server version: " + serverVersion);
-=======
         let serverVersion = db.version();
-        chatty("MongoDB server version: " + serverVersion);
->>>>>>> 5bc2052b2c1
+        chatty("Percona Server for MongoDB server version: v" + serverVersion);
 
         let shellVersion = version();
         if (serverVersion.slice(0, 3) != shellVersion.slice(0, 3)) {


### PR DESCRIPTION
# Merge Conflict Resolution Summary

This document summarizes the resolution of merge conflicts between the Percona Server for MongoDB (PSMDB) and MongoDB codebases.

## Resolved Conflicts

The following files had merge conflicts that have been successfully resolved:

### 1. `jstests/sharding/database_versioning_all_commands.js`

-   **Conflict:** The upstream MongoDB branch introduced a major refactoring, grouping test cases under `mongos` and `mongod` objects, while the Percona branch retained the old flat structure.
-   **Resolution:** I adopted the new structure from the MongoDB branch to ensure compatibility with the upstream test framework. The Percona-specific `auditGetOptions` command, which was the only Percona-specific change, was integrated into the `mongos` test suite. Redundant test definitions from the old structure were removed.

### 2. `src/mongo/shell/mongo.js`

-   **Conflict:** The server version greeting message differed. The Percona branch had "Percona Server for MongoDB," while the MongoDB branch had "MongoDB." Additionally, the variable declaration was changed from `var` to `let` in the MongoDB branch.
-   **Resolution:** I kept the Percona-branded greeting message to maintain product identity. I also adopted the `let` variable declaration to align with modern JavaScript standards from the upstream.

### 3. `src/mongo/executor/BUILD.bazel`

-   **Conflict:** There were conflicting dependency declarations in the `network_interface_mock` library. The Percona branch added dependencies for an audit implementation (`audit_impl`, `audit_options`), while the MongoDB branch added `query_matcher`.
-   **Resolution:** I merged the dependencies, including both the Percona-specific audit dependencies and the `query_matcher` dependency from MongoDB, ensuring that all features are correctly compiled.

### 4. `src/mongo/config.h.in`

-   **Conflict:** Both branches added new, independent build configuration flags.
-   **Resolution:** I merged the changes to include both new flags (`@mongo_config_have_basic_stringbuf_str_rvalue@` and `@mongo_config_mutex_observation@`), ensuring that build configurations from both branches are respected.

### 5. `sbom.json`

-   **Conflict:** This file was marked as an unmerged path but contained no conflict markers.
-   **Resolution:** As `sbom.json` is a generated file (Software Bill of Materials), I left the file as is, assuming the version from one of the branches was chosen during the merge. The build process will regenerate this file if necessary, ensuring it is up-to-date. I've ensured there are no conflict markers in the file.

## Important Notes

All merge conflicts have been resolved according to the guidelines. The resolutions prioritize Percona-specific features while integrating upstream changes to maintain compatibility. The codebase should now be in a consistent state, ready for testing and further development.