### PR TITLE
MergAI: Automated Merge Conflict Resolution [799abfd7a353 into d69339dde9f0]

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_init.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_init.cpp
@@ -149,27 +149,6 @@ public:
             wtConfig.logEnabled = false;
         }
 <<<<<<< HEAD
-        auto kv =
-            std::make_unique<WiredTigerKVEngine>(std::string{getCanonicalName()},
-                                                 params.dbpath,
-                                                 getGlobalServiceContext()->getFastClockSource(),
-                                                 std::move(wtConfig),
-                                                 params.repair,
-                                                 isReplSet,
-                                                 shouldRecoverFromOplogAsStandalone,
-                                                 inStandaloneMode,
-                                                 opCtx->getServiceContext()->getPeriodicRunner());
-||||||| 78d0eda2b55
-        auto kv =
-            std::make_unique<WiredTigerKVEngine>(std::string{getCanonicalName()},
-                                                 params.dbpath,
-                                                 getGlobalServiceContext()->getFastClockSource(),
-                                                 std::move(wtConfig),
-                                                 params.repair,
-                                                 isReplSet,
-                                                 shouldRecoverFromOplogAsStandalone,
-                                                 inStandaloneMode);
-=======
         auto kv = std::make_unique<WiredTigerKVEngine>(
             std::string{getCanonicalName()},
             params.dbpath,
@@ -179,7 +158,8 @@ public:
             params.repair,
             isReplSet,
             shouldRecoverFromOplogAsStandalone,
-            inStandaloneMode);
+            inStandaloneMode,
+            opCtx->getServiceContext()->getPeriodicRunner());
 >>>>>>> 799abfd7a353be84b3e5f41420afa23dc984f453
         kv->setRecordStoreExtraOptions(wiredTigerGlobalOptions.collectionConfig);
         kv->setSortedDataInterfaceExtraOptions(wiredTigerGlobalOptions.indexConfig);

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_init.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_init.cpp
@@ -148,7 +148,6 @@ public:
         if (params.inMemory) {
             wtConfig.logEnabled = false;
         }
-<<<<<<< HEAD
         auto kv = std::make_unique<WiredTigerKVEngine>(
             std::string{getCanonicalName()},
             params.dbpath,
@@ -160,7 +159,6 @@ public:
             shouldRecoverFromOplogAsStandalone,
             inStandaloneMode,
             opCtx->getServiceContext()->getPeriodicRunner());
->>>>>>> 799abfd7a353be84b3e5f41420afa23dc984f453
         kv->setRecordStoreExtraOptions(wiredTigerGlobalOptions.collectionConfig);
         kv->setSortedDataInterfaceExtraOptions(wiredTigerGlobalOptions.indexConfig);
 

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -1034,7 +1034,6 @@ std::vector<std::string> WiredTigerKVEngineBase::_wtGetAllIdents(
     return all;
 }
 
-<<<<<<< HEAD
 WiredTigerKVEngine::WiredTigerKVEngine(
     const std::string& canonicalName,
     const std::string& path,
@@ -1047,7 +1046,6 @@ WiredTigerKVEngine::WiredTigerKVEngine(
     bool inStandaloneMode,
     PeriodicRunner* periodicRunner,
     const encryption::MasterKeyProviderFactory& keyProviderFactory)
->>>>>>> 799abfd7a353be84b3e5f41420afa23dc984f453
     : WiredTigerKVEngineBase(canonicalName, path, clockSource, std::move(wtConfig)),
       _restEncr(DataAtRestEncryption::create(encryptionGlobalParams,
                                              boost::filesystem::path(path),

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -1040,31 +1040,13 @@ WiredTigerKVEngine::WiredTigerKVEngine(
     const std::string& path,
     ClockSource* clockSource,
     WiredTigerConfig wtConfig,
+    const WiredTigerExtensions& wtExtensions,
     bool repair,
     bool isReplSet,
     bool shouldRecoverFromOplogAsStandalone,
     bool inStandaloneMode,
     PeriodicRunner* periodicRunner,
     const encryption::MasterKeyProviderFactory& keyProviderFactory)
-||||||| 78d0eda2b55
-WiredTigerKVEngine::WiredTigerKVEngine(const std::string& canonicalName,
-                                       const std::string& path,
-                                       ClockSource* clockSource,
-                                       WiredTigerConfig wtConfig,
-                                       bool repair,
-                                       bool isReplSet,
-                                       bool shouldRecoverFromOplogAsStandalone,
-                                       bool inStandaloneMode)
-=======
-WiredTigerKVEngine::WiredTigerKVEngine(const std::string& canonicalName,
-                                       const std::string& path,
-                                       ClockSource* clockSource,
-                                       WiredTigerConfig wtConfig,
-                                       const WiredTigerExtensions& wtExtensions,
-                                       bool repair,
-                                       bool isReplSet,
-                                       bool shouldRecoverFromOplogAsStandalone,
-                                       bool inStandaloneMode)
 >>>>>>> 799abfd7a353be84b3e5f41420afa23dc984f453
     : WiredTigerKVEngineBase(canonicalName, path, clockSource, std::move(wtConfig)),
       _restEncr(DataAtRestEncryption::create(encryptionGlobalParams,


### PR DESCRIPTION
# Conflict Solution
## Solution Summary

The merge conflict was resolved by updating the `WiredTigerKVEngine` constructor to accommodate parameters from both diverging branches. Specifically, the constructor signature in `wiredtiger_kv_engine.cpp` and its corresponding declaration in `wiredtiger_kv_engine.h` were modified to include `const WiredTigerExtensions& wtExtensions` from the upstream changes, alongside `PeriodicRunner* periodicRunner` and `const encryption::MasterKeyProviderFactory& keyProviderFactory` from the Percona-specific branch. The instantiation of `WiredTigerKVEngine` in `wiredtiger_init.cpp` was also updated to pass all the required arguments in the correct order, ensuring that both upstream features and internal enhancements are properly initialized.

## Resolved files
| File Path | Resolution |
|-----------|------------|
| `src/mongo/db/storage/wiredtiger/wiredtiger_init.cpp` | The conflict in this file was in the `std::make_unique<WiredTigerKVEngine>` call. It was resolved by merging arguments from both branches, providing both the new `WiredTigerExtensions` and the existing `PeriodicRunner` to the constructor, and adopting the more context-specific `opCtx->getServiceContext()->getFastClockSource()` for the clock source. |
| `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp` | The conflict was in the `WiredTigerKVEngine` constructor definition. It was resolved by creating a new signature that includes `const WiredTigerExtensions& wtExtensions` from the incoming branch and `PeriodicRunner* periodicRunner` and `const encryption::MasterKeyProviderFactory& keyProviderFactory` from our branch, ensuring all features are supported. |

## Unresolved files
All conflicts have been resolved.

## Review Notes

The file `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h` was not part of the conflict but had to be modified to reflect the new constructor signature. An include for `wiredtiger_extensions.h` and a forward declaration for `WiredTigerExtensions` were added, and the constructor declaration was updated. Please review to ensure this is correct.
## Stats
### Models

| Model | Requests | Errors | Latency (ms) | Prompt Tokens | Candidate tokens | Cached tokens | Thoughts tokens | Tool tokens | Total tokens |
|-------|----------|--------|--------------|---------------|------------------|---------------|-----------------|-------------|--------------|
| gemini-2.5-flash-lite | 1 | 0 | 3168 | 5800 | 132 | 0 | 373 | 0 | 6305 | $0.000000 |
| gemini-2.5-pro | 4 | 0 | 160921 | 64125 | 1606 | 15088 | 10747 | 0 | 76478 | $0.000000 |