### PR TITLE
MergAI: Automated Merge Conflict Resolution [af0dac46ec6c into 49e3d6b36a4f]

### DIFF
--- a/src/mongo/db/storage/wiredtiger/BUILD.bazel
+++ b/src/mongo/db/storage/wiredtiger/BUILD.bazel
@@ -48,13 +48,7 @@ mongo_cc_library(
         "encryption_extension.c",
         "encryption_keydb.cpp",
         "spill_wiredtiger_kv_engine.cpp",
-<<<<<<< HEAD
-        "spill_wiredtiger_record_store.cpp",
         "wiredtiger_backup_cursor_hooks.cpp",
-||||||| d4a04783e72
-        "spill_wiredtiger_record_store.cpp",
-=======
->>>>>>> af0dac46ec6c21abb74cd3ba9b035e472272127c
         "wiredtiger_begin_transaction_block.cpp",
         "wiredtiger_compiled_configuration.cpp",
         "wiredtiger_connection.cpp",
@@ -85,13 +79,7 @@ mongo_cc_library(
         "encryption_keydb_c_api.h",
         "spill_recovery_unit.h",
         "spill_wiredtiger_kv_engine.h",
-<<<<<<< HEAD
-        "spill_wiredtiger_record_store.h",
         "wiredtiger_backup_cursor_hooks.h",
-||||||| d4a04783e72
-        "spill_wiredtiger_record_store.h",
-=======
->>>>>>> af0dac46ec6c21abb74cd3ba9b035e472272127c
         "wiredtiger_begin_transaction_block.h",
         "wiredtiger_compiled_configuration.h",
         "wiredtiger_connection.h",


### PR DESCRIPTION
# Conflict Solution
## Solution Summary

Resolved merge conflict in src/mongo/db/storage/wiredtiger/BUILD.bazel

## Resolved files
| File Path | Resolution |
|-----------|------------|
| `src/mongo/db/storage/wiredtiger/BUILD.bazel` | The conflict in `src/mongo/db/storage/wiredtiger/BUILD.bazel` was resolved by accepting the incoming change which removes `spill_wiredtiger_record_store.cpp` and `spill_wiredtiger_record_store.h` as part of the work to replace the spill record store with a regular record store. The Percona-specific addition of `wiredtiger_backup_cursor_hooks.cpp` and `wiredtiger_backup_cursor_hooks.h` from our branch was preserved as it is unrelated to the upstream changes. |

## Unresolved files
All conflicts have been resolved.

## Review Notes

The changes in `src/mongo/db/storage/wiredtiger/BUILD.bazel` reflect the removal of the spill record store files, which is an intended change from the upstream repository. The Percona-specific backup cursor hook files have been retained. Please review to ensure no other dependencies are affected by this build file change.
