### PR TITLE
MergAI Solution: Resolve conflicts for merge 094bcb08ba6

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -211,13 +211,7 @@
   "moduleExtensions": {
     "//bazel:bzlmod.bzl%setup_mongo_python_toolchains": {
       "general": {
-<<<<<<< HEAD (UNRESOLVED)
-        "bzlTransitiveDigest": "YyPGLMC0nHT6z0vyn4KLfyiFJkAs0xu78iipK87sK5s=",
-||||||| 6d1d857e312 (UNRESOLVED)
-        "bzlTransitiveDigest": "+A8+m4Yrx4uimRvBWXvBV3YBqdtE8BnO1wrTKXhAxA0=",
-======= (UNRESOLVED)
-        "bzlTransitiveDigest": "d7d7d90UiWbgNAe+UNjVp0658ntOeokEMK2OPybABow=",
->>>>>>> 094bcb08ba652cabba2c501989e119dbbdae475a (UNRESOLVED)
+        "bzlTransitiveDigest": "TZM0+wnM4ewg9sF+wJP8cH64I/PkJxsUIkWHALtIZoQ=",
         "usagesDigest": "bUxjq9n+hj2YwYT/lcSP4lHyQ2GVy5JpFgSmddUqUZg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -211,13 +211,13 @@
   "moduleExtensions": {
     "//bazel:bzlmod.bzl%setup_mongo_python_toolchains": {
       "general": {
-<<<<<<< HEAD
+<<<<<<< HEAD (UNRESOLVED)
         "bzlTransitiveDigest": "YyPGLMC0nHT6z0vyn4KLfyiFJkAs0xu78iipK87sK5s=",
-||||||| 6d1d857e312
+||||||| 6d1d857e312 (UNRESOLVED)
         "bzlTransitiveDigest": "+A8+m4Yrx4uimRvBWXvBV3YBqdtE8BnO1wrTKXhAxA0=",
-=======
+======= (UNRESOLVED)
         "bzlTransitiveDigest": "d7d7d90UiWbgNAe+UNjVp0658ntOeokEMK2OPybABow=",
->>>>>>> 094bcb08ba652cabba2c501989e119dbbdae475a
+>>>>>>> 094bcb08ba652cabba2c501989e119dbbdae475a (UNRESOLVED)
         "usagesDigest": "bUxjq9n+hj2YwYT/lcSP4lHyQ2GVy5JpFgSmddUqUZg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel/utils.bzl
+++ b/bazel/utils.bzl
@@ -162,13 +162,9 @@ def get_host_distro_major_version(repository_ctx):
         "Red Hat Enterprise Linux 8*": "rhel8",
         "Red Hat Enterprise Linux 9*": "rhel9",
         "Red Hat Enterprise Linux 10*": "rhel10",
-<<<<<<< HEAD
         "Oracle Linux Server 8*": "rhel8",
         "Oracle Linux Server 9*": "rhel9",
-||||||| 6d1d857e312
-=======
         "Fedora*": "rhel10",
->>>>>>> 094bcb08ba652cabba2c501989e119dbbdae475a
         "SLES 15*": "suse15",
     }
 


### PR DESCRIPTION
## Solution Summary

Resolved conflict in `bazel/utils.bzl` by merging changes from both branches. Left `MODULE.bazel.lock` unresolved as it's a generated lock file that requires regeneration.

## Resolved Files
| File Path | Resolution |
|-----------|------------|
| `bazel/utils.bzl` | The conflict in `bazel/utils.bzl` was resolved by merging the logic from both `HEAD` and the incoming commit. Percona-specific changes for 'Oracle Linux Server 8' and 'Oracle Linux Server 9' were retained from `HEAD`, while the addition of 'Fedora' support from the incoming commit was also incorporated. This ensures that both Percona's features and the upstream changes from MongoDB are preserved. |

## Unresolved Files
| File Path | Issue |
|-----------|-------|
| `MODULE.bazel.lock` | This file is a dependency lock file and could not be resolved automatically. Both branches made changes that resulted in a different `bzlTransitiveDigest`. Manually choosing one over the other would likely lead to a broken build. This file should be regenerated after the merge is complete by running the appropriate bazel command to update dependencies. |

## Review Notes

The merge conflict in `bazel/utils.bzl` has been resolved. However, `MODULE.bazel.lock` still contains conflict markers. After reviewing the merge, please run the necessary Bazel command to regenerate the lock file to ensure all dependencies are correctly resolved.

<details>
<summary>Agent Stats</summary>

**Agent:** gemini_cli (version 0.27.3)

| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| gemini-2.5-pro | 39536 | 539 | 19398 | 1906 | 0 | 41981 |

</details>