### PR TITLE
Resolve conflicts for merge '9ec2f30b6bc' into 'PSMDB-1931-merging-workflow'

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -211,13 +211,7 @@
   "moduleExtensions": {
     "//bazel:bzlmod.bzl%setup_mongo_python_toolchains": {
       "general": {
-<<<<<<< HEAD
-        "bzlTransitiveDigest": "YyPGLMC0nHT6z0vyn4KLfyiFJkAs0xu78iipK87sK5s=",
-||||||| 9e55e7357b5
-        "bzlTransitiveDigest": "+A8+m4Yrx4uimRvBWXvBV3YBqdtE8BnO1wrTKXhAxA0=",
-=======
-        "bzlTransitiveDigest": "d7d7d90UiWbgNAe+UNjVp0658ntOeokEMK2OPybABow=",
->>>>>>> 9ec2f30b6bcd5031becdf788725379521b60a0a4
+        "bzlTransitiveDigest": "TZM0+wnM4ewg9sF+wJP8cH64I/PkJxsUIkWHALtIZoQ=",
         "usagesDigest": "bUxjq9n+hj2YwYT/lcSP4lHyQ2GVy5JpFgSmddUqUZg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel/utils.bzl
+++ b/bazel/utils.bzl
@@ -162,13 +162,9 @@ def get_host_distro_major_version(repository_ctx):
         "Red Hat Enterprise Linux 8*": "rhel8",
         "Red Hat Enterprise Linux 9*": "rhel9",
         "Red Hat Enterprise Linux 10*": "rhel10",
-<<<<<<< HEAD
         "Oracle Linux Server 8*": "rhel8",
         "Oracle Linux Server 9*": "rhel9",
-||||||| 9e55e7357b5
-=======
         "Fedora*": "rhel10",
->>>>>>> 9ec2f30b6bcd5031becdf788725379521b60a0a4
         "SLES 15*": "suse15",
     }
 


### PR DESCRIPTION
# Merge Info

- **Target Branch:** `PSMDB-1931-merging-workflow`
- **Target Branch SHA:** [`edafae46b71b579a30ed03a675e8e2e25ee8db23`](https://github.com/plebioda/percona-server-mongodb/commit/edafae46b71b579a30ed03a675e8e2e25ee8db23)
- **Merge Commit:** [`9ec2f30b6bcd5031becdf788725379521b60a0a4`](https://github.com/plebioda/percona-server-mongodb/commit/9ec2f30b6bcd5031becdf788725379521b60a0a4)


# Merge Context

- **Number of merged commits:** 45
- **Auto-merged files:** 4



## Auto-Merged Files


- `bazel/utils.bzl`

- `src/mongo/db/initialize_server_global_state.cpp`

- `src/mongo/db/pipeline/BUILD.bazel`

- `src/third_party/wiredtiger/src/include/wiredtiger.h.in`



**Merged with strategy:** ort



<details>
<summary>Show details</summary>

| Commit | Summary |
|------------|---------|
| [`9ec2f30b6bcd5031becdf788725379521b60a0a4`](https://github.com/plebioda/percona-server-mongodb/commit/9ec2f30b6bcd5031becdf788725379521b60a0a4) | SERVER-118521: Add support for Fedora distro (#47277) |
| [`0bca3c14715ac48414df60f69198f35a73b6b005`](https://github.com/plebioda/percona-server-mongodb/commit/0bca3c14715ac48414df60f69198f35a73b6b005) | SERVER-118494: Update test_repos.conf to point to latest query-correctness-tests-1 (#47301) |
| [`6d1d857e312df93ec78bacb3a8ef8e4b961efafa`](https://github.com/plebioda/percona-server-mongodb/commit/6d1d857e312df93ec78bacb3a8ef8e4b961efafa) | Import wiredtiger: a463216924b637eb7b3affeb3b316e62fc4558af from branch mongodb-master (#47284) |
| [`bf50dcfcff8bdbd82ca16561405e23f8d3dabc28`](https://github.com/plebioda/percona-server-mongodb/commit/bf50dcfcff8bdbd82ca16561405e23f8d3dabc28) | SERVER-117940 Metrics for CMS refresh config (#47296) |
| [`8071258bd4d3e11728ec07857040123f3b9d8076`](https://github.com/plebioda/percona-server-mongodb/commit/8071258bd4d3e11728ec07857040123f3b9d8076) | SERVER-118516: Make Streams Binaries Public Temporarily for x86_64 (#47293) |
| [`2172ce3864dc3c3fd3c33c882116d348296e7ac6`](https://github.com/plebioda/percona-server-mongodb/commit/2172ce3864dc3c3fd3c33c882116d348296e7ac6) | SERVER-117854 Add assert on inf numberfor GranularityRounderPowersOfTwo (#47008) |
| [`564a579b26c6acfbc2b33e0ab5a7888d7aa10887`](https://github.com/plebioda/percona-server-mongodb/commit/564a579b26c6acfbc2b33e0ab5a7888d7aa10887) | Revert "SERVER-118494: Update test_repos.conf to point to latest query-correctness-tests-1 commit (#47257)" (#47288) |
| [`337aba8985c8269cff874c8d6733afdf672aaa7b`](https://github.com/plebioda/percona-server-mongodb/commit/337aba8985c8269cff874c8d6733afdf672aaa7b) | SERVER-115556 Add missing join to OCSPManager shutdown (#46881) |
| [`4205ea87d4f91f9ca10ce05295cc74552982fbea`](https://github.com/plebioda/percona-server-mongodb/commit/4205ea87d4f91f9ca10ce05295cc74552982fbea) | SERVER-118485 Fix upgrade/downgrade tests to set featureFlagExtensionViewsAndUnionWith (#47242) |
| [`2903c02520c06f1d796b5de8aa79a68b0dc24d23`](https://github.com/plebioda/percona-server-mongodb/commit/2903c02520c06f1d796b5de8aa79a68b0dc24d23) | SERVER-118491 Add `next` to container iterator API (#47248) |
| [`116c48c2baf416ae048a46cf8ace79a263f806cd`](https://github.com/plebioda/percona-server-mongodb/commit/116c48c2baf416ae048a46cf8ace79a263f806cd) | SERVER-114416 Add AL2023 ARM64 benchmarks Evergreen variant (#47117) |
| [`c799266a816f97846041ae5c172e93e3d8520def`](https://github.com/plebioda/percona-server-mongodb/commit/c799266a816f97846041ae5c172e93e3d8520def) | SERVER-118482 Remove getFromRouter fast-path for extension stage parsing (#47255) |
| [`5e60e6d895600fdc797ba9f97657b4525fadd185`](https://github.com/plebioda/percona-server-mongodb/commit/5e60e6d895600fdc797ba9f97657b4525fadd185) | SERVER-117787: Use atomics within search_task_executors.cpp (#47249) |
| [`ebac97dd4799c5e9781d4bfa0b463d6f9b2171ec`](https://github.com/plebioda/percona-server-mongodb/commit/ebac97dd4799c5e9781d4bfa0b463d6f9b2171ec) | SERVER-117564 Properly handle null device for logpath on Windows (#47172) |
| [`af6a2bcc0a673f98331ad4c6858a5e3a9253b189`](https://github.com/plebioda/percona-server-mongodb/commit/af6a2bcc0a673f98331ad4c6858a5e3a9253b189) | SERVER-118454: PDIB - Remove premature call to setInternalIdents on restart path (#47205) |
| [`01c189fe13c5d734690d245c2d5e1cb055d9c4a2`](https://github.com/plebioda/percona-server-mongodb/commit/01c189fe13c5d734690d245c2d5e1cb055d9c4a2) | SERVER-112414 Add test for timeseries and update query stats (#47078) |
| [`afd7ce1b02131b6fcfab9f8e9b17a9aeb607b625`](https://github.com/plebioda/percona-server-mongodb/commit/afd7ce1b02131b6fcfab9f8e9b17a9aeb607b625) | SERVER-108330 Use RetryStrategy in WithAutomaticRetry (#47173) |
| [`b4df72287e6aea42af26282af43fa7bdbc00be9f`](https://github.com/plebioda/percona-server-mongodb/commit/b4df72287e6aea42af26282af43fa7bdbc00be9f) | SERVER-116310: Add declared intent count to opCtx to relax opTime reservation checks (#46716) |
| [`2e51f38a5cec92d50d903d96066d0510ec63f513`](https://github.com/plebioda/percona-server-mongodb/commit/2e51f38a5cec92d50d903d96066d0510ec63f513) | SERVER-118516: Make Streams Binaries Public Temporarily (#47273) |
| [`33e1f70fc24b11bc0f9a2d927c3ccdbee6bf42fb`](https://github.com/plebioda/percona-server-mongodb/commit/33e1f70fc24b11bc0f9a2d927c3ccdbee6bf42fb) | SERVER-109455 Extract extended enumeration code from QueryPlanner::plan() (#46503) |
| [`2a7878f8fad13075fff42bb21a4497d94802748d`](https://github.com/plebioda/percona-server-mongodb/commit/2a7878f8fad13075fff42bb21a4497d94802748d) | SERVER-118447 Check for zero'd CBR metrics if SBE enabled (#47198) |
| [`b52264249144558ab7033bb8bc71d0912fac29a8`](https://github.com/plebioda/percona-server-mongodb/commit/b52264249144558ab7033bb8bc71d0912fac29a8) | SERVER-118513 remove streams 3rd party ref from coverity build (#47271) |
| [`8cd8da5f4b26791881e3f213fe3b8f261edd941f`](https://github.com/plebioda/percona-server-mongodb/commit/8cd8da5f4b26791881e3f213fe3b8f261edd941f) | SERVER-118494: Update test_repos.conf to point to latest query-correctness-tests-1 commit (#47257) |
| [`7f6d9ba6ca2f37c0347300365695e3c0633dc9c6`](https://github.com/plebioda/percona-server-mongodb/commit/7f6d9ba6ca2f37c0347300365695e3c0633dc9c6) | SERVER-118475 Clustered collection queries use sub-planning, they are not cached (#47236) |
| [`461cece6527797377af0d68cfcee828eba1424c5`](https://github.com/plebioda/percona-server-mongodb/commit/461cece6527797377af0d68cfcee828eba1424c5) | SERVER-115696 Add extension API success and failure count metrics (#46535) |
| [`1f8f33ab828e7eaab23f9fe8c48b948ae5d9251f`](https://github.com/plebioda/percona-server-mongodb/commit/1f8f33ab828e7eaab23f9fe8c48b948ae5d9251f) | SERVER-118453 - update extensions.yml (#47204) |
| [`1bca02a7429f8fa5ed62ca8e8731df43a6e16fef`](https://github.com/plebioda/percona-server-mongodb/commit/1bca02a7429f8fa5ed62ca8e8731df43a6e16fef) | SERVER-118501 Pin sleep_server_status test to a single mongos (#47264) |
| [`8dea2535392e062fd1b2dd742559e01f223b8314`](https://github.com/plebioda/percona-server-mongodb/commit/8dea2535392e062fd1b2dd742559e01f223b8314) | SERVER-116271 Basic framework for PBT (#46970) |
| [`365d187a7d1e8b608cd112e4e9d527028077454b`](https://github.com/plebioda/percona-server-mongodb/commit/365d187a7d1e8b608cd112e4e9d527028077454b) | SERVER-118502 last missing tags for modularity marking (#47265) |
| [`4faa2ee576296b3fad45069cb74e3ae01802f7d6`](https://github.com/plebioda/percona-server-mongodb/commit/4faa2ee576296b3fad45069cb74e3ae01802f7d6) | SERVER-116178 Add resmoke passthrough that loads $vectorSearch extension (#47081) |
| [`ac17ed6c3a97ee797eee680a251ce586fe812703`](https://github.com/plebioda/percona-server-mongodb/commit/ac17ed6c3a97ee797eee680a251ce586fe812703) | SERVER-117277: Inline WorkingSet construction when not used elsewhere (#47142) |
| [`f5a68dc08880c9cf71d917165994dccf1eb0c6f4`](https://github.com/plebioda/percona-server-mongodb/commit/f5a68dc08880c9cf71d917165994dccf1eb0c6f4) | SERVER-74313 Do not throw InvalidView if looking for a nss linked to valid view (#46860) |
| [`faaac5007421e162d5d1f39461923e05b44bad03`](https://github.com/plebioda/percona-server-mongodb/commit/faaac5007421e162d5d1f39461923e05b44bad03) | SERVER-117480 Update test utilities for costed plan enumeration (#46854) |
| [`5378c53014b4243cf7025f0f63863bbe94edb999`](https://github.com/plebioda/percona-server-mongodb/commit/5378c53014b4243cf7025f0f63863bbe94edb999) | SERVER-117923 Apply view policy in subpipelines (#47162) |
| [`eaeaed0ef426862516207725d464610af9582e57`](https://github.com/plebioda/percona-server-mongodb/commit/eaeaed0ef426862516207725d464610af9582e57) | SERVER-117836 Fix applyOps with rrid when getting DuplicateKey error. (#47089) |
| [`77fc2a762366e007d2e5b08cd096f7c7f6ef9b6c`](https://github.com/plebioda/percona-server-mongodb/commit/77fc2a762366e007d2e5b08cd096f7c7f6ef9b6c) | SERVER-117016 Fix backward ternary operator to include metadata of stashed document (#47100) |
| [`d916f7636079b34451c471bc46fea4cb2abc0df8`](https://github.com/plebioda/percona-server-mongodb/commit/d916f7636079b34451c471bc46fea4cb2abc0df8) | Revert "SERVER-117895 Disable featureFlagTimeseriesUpdatesSupport in allFeatureFlags variants (#47125)" (#47246) |
| [`4afb05822c9d85f2c898a781f61324158ddff56f`](https://github.com/plebioda/percona-server-mongodb/commit/4afb05822c9d85f2c898a781f61324158ddff56f) | Revert "SERVER-106534 Add IngressRequestRateLimiter parameters to config fuzzer" (#47241) |
| [`3f0ee3e7d8e462ba6750c5170d713726c9e60a14`](https://github.com/plebioda/percona-server-mongodb/commit/3f0ee3e7d8e462ba6750c5170d713726c9e60a14) | SERVER-115584 detect huge procfs files during FTDC collection (#45936) |
| [`7c2f4a01337baeca8c98eae7147679591a0b93d1`](https://github.com/plebioda/percona-server-mongodb/commit/7c2f4a01337baeca8c98eae7147679591a0b93d1) | SERVER-115811 Expose timeseries collection consistently with view during timeseries upgrade/downgrade (#47228) |
| [`06de9d50cd40c32d4ffea7b4167f14f83664e5a4`](https://github.com/plebioda/percona-server-mongodb/commit/06de9d50cd40c32d4ffea7b4167f14f83664e5a4) | SERVER-116994: Make sharded view $vectorSearch toggle dependent on featureFlagExtensionViewsAndUnionWith (#47093) |
| [`55d3cc2af70d16625167257698c77791f6e9046d`](https://github.com/plebioda/percona-server-mongodb/commit/55d3cc2af70d16625167257698c77791f6e9046d) | SERVER-117304: Remove empty multiline objects in tojson formatting (#47177) |
| [`fa392c22626f970806effaca3c23f830608e9d34`](https://github.com/plebioda/percona-server-mongodb/commit/fa392c22626f970806effaca3c23f830608e9d34) | SERVER-118003 stale mongos aware (#47137) |
| [`6edba451efbfe789a83f72c26a2daab561806507`](https://github.com/plebioda/percona-server-mongodb/commit/6edba451efbfe789a83f72c26a2daab561806507) | SERVER-118472: Clean-up at the end of query_settings_cmds.js (#47223) |
| [`9e648d6c9245da371e95764925206ece58a4d4c8`](https://github.com/plebioda/percona-server-mongodb/commit/9e648d6c9245da371e95764925206ece58a4d4c8) | SERVER-117877. Accept unoptimized skip=0 router stages (#47040) |

</details>


# Conflict Context

- **Base Commit:** [`9e55e7357b58f1a317c75fa25a4bc77e12ce57cc`](https://github.com/plebioda/percona-server-mongodb/commit/9e55e7357b58f1a317c75fa25a4bc77e12ce57cc)
- **Ours Commit:** [`edafae46b71b579a30ed03a675e8e2e25ee8db23`](https://github.com/plebioda/percona-server-mongodb/commit/edafae46b71b579a30ed03a675e8e2e25ee8db23)
- **Theirs Commit:** [`9ec2f30b6bcd5031becdf788725379521b60a0a4`](https://github.com/plebioda/percona-server-mongodb/commit/9ec2f30b6bcd5031becdf788725379521b60a0a4)

## Conflicted Files

| Path | Conflict Type |
|------|---------------|
| `MODULE.bazel.lock` | both modified |
| `bazel/utils.bzl` | both modified |


<details>
<summary>Conflict details</summary>

## Their Commits

| Path | Commit | Message |
|------|--------|---------|
| `MODULE.bazel.lock` | [`9ec2f30b6bcd5031becdf788725379521b60a0a4`](https://github.com/plebioda/percona-server-mongodb/commit/9ec2f30b6bcd5031becdf788725379521b60a0a4) | SERVER-118521: Add support for Fedora distro (#47277) |
| `bazel/utils.bzl` | [`9ec2f30b6bcd5031becdf788725379521b60a0a4`](https://github.com/plebioda/percona-server-mongodb/commit/9ec2f30b6bcd5031becdf788725379521b60a0a4) | SERVER-118521: Add support for Fedora distro (#47277) |

</details>



# Solutions

## Solution 1
### Summary

Resolved merge conflicts by combining changes in `bazel/utils.bzl` and regenerating `MODULE.bazel.lock` as per project guidelines.

**By:** Agent (gemini_cli v0.29.0)

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `bazel/utils.bzl` | Successfully merged the conflicting changes by incorporating both Percona's Oracle Linux mappings and MongoDB's Fedora mapping into the `_DISTRO_PATTERN_MAP`. |
| `MODULE.bazel.lock` | Resolved the conflict by temporarily accepting the 'ours' version to remove conflict markers, and then regenerated the file by executing `bazel query //... >/dev/null` as required by the project's conflict resolution guidelines for this specific file. |


### Unresolved Files

All conflicts have been resolved.


### Modified Files

No additional files were modified.


### Review Notes

The merge conflict in `bazel/utils.bzl` was a simple addition on both sides, which were combined. `MODULE.bazel.lock` was handled according to the specific instructions provided, which involved running a `bazel` command to update it after removing the conflict markers.


<details>
<summary>Agent Stats</summary>


**Agent:** gemini_cli (version 0.29.0)



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| gemini-2.5-pro | 203150 | 892 | 49831 | 1388 | 0 | 205430 |


</details>



---

*note created with mergai 0.1.dev111+gc2eff4572.d20260220*
