### PR TITLE
Resolve conflicts for merge '9b770d3df99' into 'PSMDB-1931-merging-workflow'

### DIFF
--- a/sbom.json
+++ b/sbom.json
@@ -2505,53 +2505,6 @@
         ]
       },
       "scope": "required"
-<<<<<<< HEAD
-    },
-    {
-      "supplier": {
-        "name": "Organization: github"
-      },
-      "name": "libarchive",
-      "version": "3.8.4",
-      "licenses": [
-        {
-          "license": {
-            "name": "A mix of BSD-2-Clause and others",
-            "url": "https://github.com/libarchive/libarchive/blob/v3.4.0/COPYING"
-          }
-        }
-      ],
-      "purl": "pkg:github/libarchive/libarchive@v3.8.4",
-      "properties": [
-        {
-          "name": "internal:team_responsible",
-          "value": "Percona Server for MongoDB Team"
-        },
-        {
-          "name": "emits_persisted_data",
-          "value": "true"
-        },
-        {
-          "name": "info_link",
-          "value": "https://www.libarchive.org"
-        },
-        {
-          "name": "import_script_path",
-          "value": "src/third_party/libarchive/scripts/import.sh"
-        }
-      ],
-      "type": "library",
-      "bom-ref": "pkg:github/libarchive/libarchive@v3.8.4",
-      "evidence": {
-        "occurrences": [
-          {
-            "location": "src/third_party/libarchive"
-          }
-        ]
-      },
-      "scope": "required"
-||||||| dffa5f381ab
-=======
     },
     {
       "type": "library",
@@ -2610,7 +2563,50 @@
         ]
       },
       "scope": "excluded"
->>>>>>> 9b770d3df99d8746c071419ba5fad4d4b6b9f659
+    },
+    {
+      "supplier": {
+        "name": "Organization: github"
+      },
+      "name": "libarchive",
+      "version": "3.8.4",
+      "licenses": [
+        {
+          "license": {
+            "name": "A mix of BSD-2-Clause and others",
+            "url": "https://github.com/libarchive/libarchive/blob/v3.4.0/COPYING"
+          }
+        }
+      ],
+      "purl": "pkg:github/libarchive/libarchive@v3.8.4",
+      "properties": [
+        {
+          "name": "internal:team_responsible",
+          "value": "Percona Server for MongoDB Team"
+        },
+        {
+          "name": "emits_persisted_data",
+          "value": "true"
+        },
+        {
+          "name": "info_link",
+          "value": "https://www.libarchive.org"
+        },
+        {
+          "name": "import_script_path",
+          "value": "src/third_party/libarchive/scripts/import.sh"
+        }
+      ],
+      "type": "library",
+      "bom-ref": "pkg:github/libarchive/libarchive@v3.8.4",
+      "evidence": {
+        "occurrences": [
+          {
+            "location": "src/third_party/libarchive"
+          }
+        ]
+      },
+      "scope": "required"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
# Merge Info

- **Target Branch:** `PSMDB-1931-merging-workflow`
- **Target Branch SHA:** [`cb3769472f17b4de00c781828782d13b0e8b5d5b`](https://github.com/plebioda/percona-server-mongodb/commit/cb3769472f17b4de00c781828782d13b0e8b5d5b)
- **Merge Commit:** [`9b770d3df99d8746c071419ba5fad4d4b6b9f659`](https://github.com/plebioda/percona-server-mongodb/commit/9b770d3df99d8746c071419ba5fad4d4b6b9f659)


# Merge Context

- **Number of merged commits:** 3
- **Auto-merged files:** 2



## Auto-Merged Files


- `MODULE.bazel.lock`

- `sbom.json`



**Merged with strategy:** ort



<details>
<summary>Show details</summary>

| Commit | Summary |
|------------|---------|
| [`9b770d3df99d8746c071419ba5fad4d4b6b9f659`](https://github.com/plebioda/percona-server-mongodb/commit/9b770d3df99d8746c071419ba5fad4d4b6b9f659) | SERVER-118522 Vendor Fuzztest (#47328) |
| [`d5122c7b20aa339232497bd9658b00899c7b0572`](https://github.com/plebioda/percona-server-mongodb/commit/d5122c7b20aa339232497bd9658b00899c7b0572) | SERVER-116272: Introduce 'validated' document schema validation level (#46706) |
| [`784adb1029b62bdad3d5d2caa8a8734cf514d9ef`](https://github.com/plebioda/percona-server-mongodb/commit/784adb1029b62bdad3d5d2caa8a8734cf514d9ef) | SERVER-119146 Serialize IFR flags in finalizePipelineAndTargetShardsForExplain (#47711) |

</details>


# Merge Description

## Summary

This merge integrates upstream changes, primarily involving dependency updates. Conflicts in `sbom.json` and `MODULE.bazel.lock` were resolved through an automatic merge strategy.


## Auto-Merged Files

| File Path | Description |
|-----------|-------------|
| `MODULE.bazel.lock` | This file was auto-merged by git's 'ort' strategy. As per project guidelines, this file cannot be merged manually and requires regeneration to ensure correctness. |
| `sbom.json` | The conflict was resolved by combining the new dependency definitions that were added in both branches into the Software Bill of Materials. |


## Review Notes

IMPORTANT: The `MODULE.bazel.lock` file was automatically merged and must be regenerated. After all other conflicts are resolved, please run `bazel query //... >/dev/null` to correctly update the file. Also, please give a quick review to `sbom.json` to verify the merged dependency data is correct.


<details>
<summary>Agent Stats</summary>


**Agent:** gemini_cli (version 0.29.0)



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| gemini-2.5-pro | 10609 | 212 | 0 | 1744 | 0 | 12565 |


</details>



# Conflict Context

- **Base Commit:** [`dffa5f381ab8149344e9b64e020e8a4e6880a23e`](https://github.com/plebioda/percona-server-mongodb/commit/dffa5f381ab8149344e9b64e020e8a4e6880a23e)
- **Ours Commit:** [`cb3769472f17b4de00c781828782d13b0e8b5d5b`](https://github.com/plebioda/percona-server-mongodb/commit/cb3769472f17b4de00c781828782d13b0e8b5d5b)
- **Theirs Commit:** [`9b770d3df99d8746c071419ba5fad4d4b6b9f659`](https://github.com/plebioda/percona-server-mongodb/commit/9b770d3df99d8746c071419ba5fad4d4b6b9f659)

## Conflicted Files

| Path | Conflict Type |
|------|---------------|
| `sbom.json` | both modified |


<details>
<summary>Conflict details</summary>

## Their Commits

| Path | Commit | Message |
|------|--------|---------|
| `sbom.json` | [`9b770d3df99d8746c071419ba5fad4d4b6b9f659`](https://github.com/plebioda/percona-server-mongodb/commit/9b770d3df99d8746c071419ba5fad4d4b6b9f659) | SERVER-118522 Vendor Fuzztest (#47328) |

</details>



# Solutions

## Solution 1
### Summary

Resolved merge conflict in sbom.json by merging parallel additions to the 'components' array.

**By:** Agent (gemini_cli v0.29.0)

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `sbom.json` | The conflict in sbom.json was due to both branches adding a new dependency to the 'components' list. 'ours' added 'libarchive' and 'theirs' added 'fuzztest'. I resolved the conflict by including both new components in the list. |


### Unresolved Files

All conflicts have been resolved.


### Modified Files

No additional files were modified.


### Review Notes

The 'dependencies' section appeared to be correctly auto-merged by git, so I only resolved the conflict in the 'components' section. Please verify that both 'libarchive' and 'fuzztest' are correctly referenced in both 'components' and 'dependencies'.


<details>
<summary>Agent Stats</summary>


**Agent:** gemini_cli (version 0.29.0)



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| gemini-2.5-pro | 93398 | 2034 | 64937 | 8876 | 0 | 104308 |


</details>



---

*note created with mergai 0.1.dev111+gc2eff4572.d20260220*
