### PR TITLE
Resolve conflicts for merge '61430ac26d6' into 'PSMDB-1931-merging-workflow'

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -64,14 +64,8 @@
 #include "mongo/db/storage/storage_options.h"
 #include "mongo/db/storage/storage_parameters_gen.h"
 #include "mongo/db/storage/storage_repair_observer.h"
-<<<<<<< HEAD
 #include "mongo/db/storage/wiredtiger/encryption_keydb.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_backup_cursor_hooks.h"
-#include "mongo/db/storage/wiredtiger/wiredtiger_cache_eviction_opt_out_guard.h"
-||||||| 94b7881463e
-#include "mongo/db/storage/wiredtiger/wiredtiger_cache_eviction_opt_out_guard.h"
-=======
->>>>>>> 61430ac26d642026f2755e9ceb129cae9f3852eb
 #include "mongo/db/storage/wiredtiger/wiredtiger_cache_pressure_monitor.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_connection.h"
 #include "mongo/db/storage/wiredtiger/wiredtiger_cursor.h"


### PR DESCRIPTION
# Merge Info

- **Target Branch:** `PSMDB-1931-merging-workflow`
- **Target Branch SHA:** [`3e157a9357028ef70176eaf8a8abd8c1f0b255b0`](https://github.com/plebioda/percona-server-mongodb/commit/3e157a9357028ef70176eaf8a8abd8c1f0b255b0)
- **Merge Commit:** [`61430ac26d642026f2755e9ceb129cae9f3852eb`](https://github.com/plebioda/percona-server-mongodb/commit/61430ac26d642026f2755e9ceb129cae9f3852eb)


# Merge Context

- **Number of merged commits:** 86
- **Auto-merged files:** 11


## Important Files Modified

- `src/mongo/db/auth/sasl_plain_server_conversation.cpp`

- `src/mongo/db/auth/sasl_scram_server_conversation.cpp`

- `src/mongo/db/repl/initial_sync/initial_syncer.cpp`

- `src/mongo/db/repl/initial_sync/initial_syncer.h`

- `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp`




## Auto-Merged Files


- `sbom.json`

- `src/mongo/client/sasl_oidc_client_conversation.cpp`

- `src/mongo/db/BUILD.bazel`

- `src/mongo/db/auth/BUILD.bazel`

- `src/mongo/db/commands/BUILD.bazel`

- `src/mongo/db/mongod_main.cpp`

- `src/mongo/db/pipeline/BUILD.bazel`

- `src/mongo/db/server_options_server_helpers.cpp`

- `src/mongo/db/storage/BUILD.bazel`

- `src/mongo/db/storage/wiredtiger/BUILD.bazel`

- `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp`



**Merged with strategy:** ort



<details>
<summary>Show details</summary>

| Commit | Summary |
|------------|---------|
| [`61430ac26d642026f2755e9ceb129cae9f3852eb`](https://github.com/plebioda/percona-server-mongodb/commit/61430ac26d642026f2755e9ceb129cae9f3852eb) | Revert "SERVER-101775 Journal flushes should not be susceptible to cache eviction stalls" (#48510) |
| [`de7274e1c0f865939c93743ea975791b7c0bb585`](https://github.com/plebioda/percona-server-mongodb/commit/de7274e1c0f865939c93743ea975791b7c0bb585) | SERVER-119618: revise reactor histograms (#48432) |
| [`c344aead7fcae2aff3cd6d35419a0f9a3746ff8d`](https://github.com/plebioda/percona-server-mongodb/commit/c344aead7fcae2aff3cd6d35419a0f9a3746ff8d) | SERVER-109563 No longer need to filter on test name (#48546) |
| [`59f4f2119edd284047207413f83d7bf503cddc4f`](https://github.com/plebioda/percona-server-mongodb/commit/59f4f2119edd284047207413f83d7bf503cddc4f) | SERVER-117268: Implement required functions in ContainerTraits for long running sorter test parameterization (#48422) |
| [`f16116efc701c986a6aa0464ab09ecc5f8122626`](https://github.com/plebioda/percona-server-mongodb/commit/f16116efc701c986a6aa0464ab09ecc5f8122626) | SERVER-11731 Enable jscore suites for distributed transactions (#46893) |
| [`40321e6a3671cd94cdcf598f4437c2cc97d06235`](https://github.com/plebioda/percona-server-mongodb/commit/40321e6a3671cd94cdcf598f4437c2cc97d06235) | SERVER-119081 retryable_writes_oplog_entries.js shoud retry on transient transaction errors (#48516) |
| [`fdbf5c65a18aa76dc8c1ddd82a9f570a133ff33f`](https://github.com/plebioda/percona-server-mongodb/commit/fdbf5c65a18aa76dc8c1ddd82a9f570a133ff33f) | SERVER-119696 Add extension that desugars into valid search-on-view stages (#48416) |
| [`c6032d1f25d4de0f42e9f435e13a6217167fec4c`](https://github.com/plebioda/percona-server-mongodb/commit/c6032d1f25d4de0f42e9f435e13a6217167fec4c) | SERVER-119632: Add streams variants to mongodb-mongo-master (#48491) |
| [`1cfd495bddaf95fbae473e9c37a05ed706367e37`](https://github.com/plebioda/percona-server-mongodb/commit/1cfd495bddaf95fbae473e9c37a05ed706367e37) | SERVER-120213: Fix memory leak caused by Deferred move assignment operator (#48493) |
| [`201cb46d7a212eae15fbefb4cd379966ea819eb5`](https://github.com/plebioda/percona-server-mongodb/commit/201cb46d7a212eae15fbefb4cd379966ea819eb5) | SERVER-120067: Make container based sorter support limits (#48418) |
| [`78bac8086cf2d8bf1cbd9bdd0c96d9bb3cde0f57`](https://github.com/plebioda/percona-server-mongodb/commit/78bac8086cf2d8bf1cbd9bdd0c96d9bb3cde0f57) | SERVER-117529 Add debug info on upsert failure (#48207) |
| [`b70c9acbc36b7d64d7342842e5279b7bae275589`](https://github.com/plebioda/percona-server-mongodb/commit/b70c9acbc36b7d64d7342842e5279b7bae275589) | SERVER-118514 DelayableTimeoutCallback ignores earlier timeout values (#48391) |
| [`78053e01fefc735e7ab50296d2232e04b8d006eb`](https://github.com/plebioda/percona-server-mongodb/commit/78053e01fefc735e7ab50296d2232e04b8d006eb) | SERVER-119883: Populate unique fields from index metadata for use in NDV estimation (#47870) |
| [`7415cbf342575872ddff06446ea108add725d96f`](https://github.com/plebioda/percona-server-mongodb/commit/7415cbf342575872ddff06446ea108add725d96f) | SERVER-119832 Add information on whether the CSS/CSR is authoritative or not (#48377) |
| [`8b22ac874af5e1c721ffcba183511e8042789311`](https://github.com/plebioda/percona-server-mongodb/commit/8b22ac874af5e1c721ffcba183511e8042789311) | SERVER-119805 Exclude unreleased IFR flags from runAllFeatureFlags (#48539) |
| [`00bec61d31e123acf5abe8becf46ab94e62bf27d`](https://github.com/plebioda/percona-server-mongodb/commit/00bec61d31e123acf5abe8becf46ab94e62bf27d) | SERVER-120244: Lower Block on Red thresholds by an additional 25% (#48536) |
| [`35e9b0717bc9f950e72b9250544ac251631d10a3`](https://github.com/plebioda/percona-server-mongodb/commit/35e9b0717bc9f950e72b9250544ac251631d10a3) | SERVER-120195 Run $zip in SBE only with upgraded AST (#48501) |
| [`95d405093399318375a4980587a186a0d57b6693`](https://github.com/plebioda/percona-server-mongodb/commit/95d405093399318375a4980587a186a0d57b6693) | SERVER-114496: Fix tests targeting system.buckets while viewless timeseries are enabled (#48315) |
| [`2def59bc180b82af9228f63c7dcc775f133abc92`](https://github.com/plebioda/percona-server-mongodb/commit/2def59bc180b82af9228f63c7dcc775f133abc92) | SERVER-120212: only use pseudo-random v4 UUIDs (#48496) |
| [`a6c7fe6ce2dd68e6e269d87e588b26f598319ad7`](https://github.com/plebioda/percona-server-mongodb/commit/a6c7fe6ce2dd68e6e269d87e588b26f598319ad7) | SERVER-119161 Fix failpoint usage in tests for multi-router test suits (#47971) |
| [`26c8df4622ce2bdd8d17d04627c2bcda06b6e6c1`](https://github.com/plebioda/percona-server-mongodb/commit/26c8df4622ce2bdd8d17d04627c2bcda06b6e6c1) | SERVER-120214 Wait for replication before restarts in dedicated_to_catalog_shard.js (#48514) |
| [`5b7322d76252e983e47b6ac7a0ea7c159f50a884`](https://github.com/plebioda/percona-server-mongodb/commit/5b7322d76252e983e47b6ac7a0ea7c159f50a884) | SERVER-120186 Improve throughput for hex encoding/decoding (#48468) |
| [`f86966df57b60c7407d210be444fcba10b9b52d7`](https://github.com/plebioda/percona-server-mongodb/commit/f86966df57b60c7407d210be444fcba10b9b52d7) | SERVER-119410: Invoke a callback when setting breakpoints in VSCode editor (#48529) |
| [`aabcf105bbd84dffcb1a9e58d9be5e66ba6ceccc`](https://github.com/plebioda/percona-server-mongodb/commit/aabcf105bbd84dffcb1a9e58d9be5e66ba6ceccc) | SERVER-119929 Make change streams oplog filter use an include list (#48198) |
| [`7d9093b79af757f35759cf9e01f6fb81f88ae816`](https://github.com/plebioda/percona-server-mongodb/commit/7d9093b79af757f35759cf9e01f6fb81f88ae816) | SERVER-119942 Move an assert out of the hot path doGetNext() (#48314) |
| [`35daf10f6ceb161cb7e07979e7bf13310b2f22ef`](https://github.com/plebioda/percona-server-mongodb/commit/35daf10f6ceb161cb7e07979e7bf13310b2f22ef) | SERVER-119966 Simplify MatchStage (#48330) |
| [`736490a04274c66324c23310a99d6453a8a9c5cb`](https://github.com/plebioda/percona-server-mongodb/commit/736490a04274c66324c23310a99d6453a8a9c5cb) | SERVER-107487 Implement egress authentication metrics emission (#47323) |
| [`95ef06b20620168df123eb38730d81d1bc1d05f3`](https://github.com/plebioda/percona-server-mongodb/commit/95ef06b20620168df123eb38730d81d1bc1d05f3) | SERVER-114310 Improve error output when running resmoke outside of venv (#48492) |
| [`32d512d6cf639a5d199ba6f7e15b9fc43056df85`](https://github.com/plebioda/percona-server-mongodb/commit/32d512d6cf639a5d199ba6f7e15b9fc43056df85) | SERVER-119595: Remove wrapping behavior for 64 bit counters (#47994) |
| [`a999b2cb41d373fa8fad78c5314903f2d39ecb58`](https://github.com/plebioda/percona-server-mongodb/commit/a999b2cb41d373fa8fad78c5314903f2d39ecb58) | SERVER-120161 Temporarily disable the CheckIdleCursors hook (#48451) |
| [`0d51c5cb6571a14e690c4774bb069d1990fd35b6`](https://github.com/plebioda/percona-server-mongodb/commit/0d51c5cb6571a14e690c4774bb069d1990fd35b6) | SERVER-119968: Add better helpers for testing otel metrics via files. (#48498) |
| [`837f0f781716da11cefae39017647f035f86ff76`](https://github.com/plebioda/percona-server-mongodb/commit/837f0f781716da11cefae39017647f035f86ff76) | SERVER-120197 Improve logging on tassert while handling bulkWrite response (#48485) |
| [`e2f23bc7473862d9a33173694f36f4b00d99944d`](https://github.com/plebioda/percona-server-mongodb/commit/e2f23bc7473862d9a33173694f36f4b00d99944d) | SERVER-108819 Avoid creating sample when answering a query with an empty filter {} (find all query) (#48243) |
| [`d5f3a150f82e2620d83c99ef0281688e3cce4c6a`](https://github.com/plebioda/percona-server-mongodb/commit/d5f3a150f82e2620d83c99ef0281688e3cce4c6a) | SERVER-117691 Add suite sharded_collections_jscore_passthrough_drop_config_cache_collections  (#48310) |
| [`b86836768f044681a61831f9fd3643cb9445dd5c`](https://github.com/plebioda/percona-server-mongodb/commit/b86836768f044681a61831f9fd3643cb9445dd5c) | SERVER-110427 Update profiling data (#48520) |
| [`789e63f102ddecc7d3b0afd4300b2abca5784212`](https://github.com/plebioda/percona-server-mongodb/commit/789e63f102ddecc7d3b0afd4300b2abca5784212) | SERVER-117084 Calibrate CPU factor & sequential/random IO (#48257) |
| [`e24d10d1ab8815d6f39af12f2b35aa8a8784cbcd`](https://github.com/plebioda/percona-server-mongodb/commit/e24d10d1ab8815d6f39af12f2b35aa8a8784cbcd) | SERVER-114582 Change ownership of ce/cost pointers (#48385) |
| [`bacc2d019fc7b0a42dfc4181997967d3aab3ee0a`](https://github.com/plebioda/percona-server-mongodb/commit/bacc2d019fc7b0a42dfc4181997967d3aab3ee0a) | SERVER-114582 Add prereqs for per-subset hinting (#48322) |
| [`00f818de5f4753fbf7c58dd7baefd106c5a062e7`](https://github.com/plebioda/percona-server-mongodb/commit/00f818de5f4753fbf7c58dd7baefd106c5a062e7) | SERVER-119803 no_causal_consistency suites with step downs must set TestData.runningWithStepdowns (#48306) |
| [`e354cc14a64951ae6ff6e17b41a1cde2c624dfc5`](https://github.com/plebioda/percona-server-mongodb/commit/e354cc14a64951ae6ff6e17b41a1cde2c624dfc5) | Revert "SERVER-117797 Implement IFR retry loop in top-level cluster runAggregate (#47254)" (#48515) |
| [`f02ef0062492a763f2b0c56a96c0b951d4b3ad75`](https://github.com/plebioda/percona-server-mongodb/commit/f02ef0062492a763f2b0c56a96c0b951d4b3ad75) | Revert "SERVER-120046 Statically link extensions in unit tests (#48490)" (#48513) |
| [`cf70af613565333682b6bd9b28f85b1e6afa4493`](https://github.com/plebioda/percona-server-mongodb/commit/cf70af613565333682b6bd9b28f85b1e6afa4493) | SERVER-119297: Convert planCacheClear commands to TypedCommand (#47964) |
| [`4158037c548ee3d6f62de08a43fe80e3fbd0aa9d`](https://github.com/plebioda/percona-server-mongodb/commit/4158037c548ee3d6f62de08a43fe80e3fbd0aa9d) | SERVER-119996 Initialize in-memory metadata as part of startup recovery (#48471) |
| [`f0983d6474d4f1b07704995ade04428bba5bfe79`](https://github.com/plebioda/percona-server-mongodb/commit/f0983d6474d4f1b07704995ade04428bba5bfe79) | SERVER-120133 Adapt extension_status_test to account for Windows exception impl. (#48488) |
| [`02b07520d410ce0467506f3bdbea29011979505c`](https://github.com/plebioda/percona-server-mongodb/commit/02b07520d410ce0467506f3bdbea29011979505c) | SERVER-120046 Statically link extensions in unit tests (#48490) |
| [`71d50959404341833b882d9961e929b9632779fc`](https://github.com/plebioda/percona-server-mongodb/commit/71d50959404341833b882d9961e929b9632779fc) | SERVER-119841 Introduce fcv_upgrade_downgrade_retryable_writes_replica_sets_jscore_passthrough suite (#48313) |
| [`065ea1f42a3d815cb95451ed9bc2e7ed5aef7df7`](https://github.com/plebioda/percona-server-mongodb/commit/065ea1f42a3d815cb95451ed9bc2e7ed5aef7df7) | SERVER-119818 Replicated fast count accounts for capped collection deletes (#48331) |
| [`f0054b5fe01026ed6d694721541cc1809e739b63`](https://github.com/plebioda/percona-server-mongodb/commit/f0054b5fe01026ed6d694721541cc1809e739b63) | Import wiredtiger: 8398ffa399b9a2ca7cffe268e20bedacb6a61f93 from branch mongodb-master (#48458) |
| [`c33d95e211cde7b3a64a0910ee007daeab9958c3`](https://github.com/plebioda/percona-server-mongodb/commit/c33d95e211cde7b3a64a0910ee007daeab9958c3) | SERVER-119679 Add auth check for updating mechanisms of user (#48178) |
| [`0cf0f11605e419f7c788c47d1ce3d47827d84d30`](https://github.com/plebioda/percona-server-mongodb/commit/0cf0f11605e419f7c788c47d1ce3d47827d84d30) | SERVER-119054 Make ShardingWriteRouter use resharding registry (#48321) |
| [`58bc053e2e8004a14091c42dfcf27ea0285ae7b1`](https://github.com/plebioda/percona-server-mongodb/commit/58bc053e2e8004a14091c42dfcf27ea0285ae7b1) | SERVER-100523 generate-matrix-suites keeps generated suites in sync with mappings (#48394) |
| [`1fc95f949c9bc3d61a0bca3b39e646858f614550`](https://github.com/plebioda/percona-server-mongodb/commit/1fc95f949c9bc3d61a0bca3b39e646858f614550) | SERVER-119926 Make timeseries tests relying on buckets count resilient to FCV upgrade/downgrade plus retryable writes (#48311) |
| [`a3b3bdc8fb38ff9220cceac199fe8c973f950c0e`](https://github.com/plebioda/percona-server-mongodb/commit/a3b3bdc8fb38ff9220cceac199fe8c973f950c0e) | SERVER-119717: Fix uninitialized scalar `fileIteratorsMaxNum` in `sorter_template_defs.h` (#48462) |
| [`238760e46e7f7cbf78a375bc3d8c13ef8b37cdcb`](https://github.com/plebioda/percona-server-mongodb/commit/238760e46e7f7cbf78a375bc3d8c13ef8b37cdcb) | SERVER-119995 Remove quadratic behavior in documentToBsonWithPaths (#48361) |
| [`205d333e110fd4e63ae2a5e83bafaa503df82c99`](https://github.com/plebioda/percona-server-mongodb/commit/205d333e110fd4e63ae2a5e83bafaa503df82c99) | SERVER-119953 Fix mongod --shutdown (#48414) |
| [`45f9bceaa9f87c41a81a9771864d934361ff8455`](https://github.com/plebioda/percona-server-mongodb/commit/45f9bceaa9f87c41a81a9771864d934361ff8455) | SERVER-120199 Temporarily disable non-negative invariant check (#48486) |
| [`0bc8bb00f918fe8b20af8b115a0e910cce54b23a`](https://github.com/plebioda/percona-server-mongodb/commit/0bc8bb00f918fe8b20af8b115a0e910cce54b23a) | SERVER-119967 convert otel_metrics.js to check otel file exporter data files instead of serverStatus (#48469) |
| [`fa47e21f635a3eded0cf82da061bacaa96c5bda3`](https://github.com/plebioda/percona-server-mongodb/commit/fa47e21f635a3eded0cf82da061bacaa96c5bda3) | SERVER-120009 Enable join costing test collscan > selective index scan (#48482) |
| [`e1d3eaa85e02de7ddce8ae6f3ff8543bc84bfc94`](https://github.com/plebioda/percona-server-mongodb/commit/e1d3eaa85e02de7ddce8ae6f3ff8543bc84bfc94) | SERVER-117515 Trigger fastcount flush from Checkpointer (#48182) |
| [`e715e166511bb470b25a6e0a4915589d77e70348`](https://github.com/plebioda/percona-server-mongodb/commit/e715e166511bb470b25a6e0a4915589d77e70348) | SERVER-119959 Insert with overwrite cursors for PDIB (#48455) |
| [`9ed2c9e55668dff85ee57056f57f4b7d87c39cd1`](https://github.com/plebioda/percona-server-mongodb/commit/9ed2c9e55668dff85ee57056f57f4b7d87c39cd1) | SERVER-119900 Start up replicated fast count manager thread on standalone nodes (#48369) |
| [`465e1909cb19129ec9fde449c9730397e828c9d1`](https://github.com/plebioda/percona-server-mongodb/commit/465e1909cb19129ec9fde449c9730397e828c9d1) | Revert "SERVER-119410: Invoke a callback when setting breakpoints in VSCode editor (#48403)" (#48480) |
| [`f6b5e39a172f082f1c1dd4e948dd3885b99fa74d`](https://github.com/plebioda/percona-server-mongodb/commit/f6b5e39a172f082f1c1dd4e948dd3885b99fa74d) | SERVER-119629 Dismiss merge cursor ownership when rebuilding the pipeline on merging shard (#48463) |
| [`fdd030d520c91f79a6a4c8c22204c4387a12009b`](https://github.com/plebioda/percona-server-mongodb/commit/fdd030d520c91f79a6a4c8c22204c4387a12009b) | SERVER-118440 Check persistence provider in replicated fast count use  (#48262) |
| [`30018a6eb35406fc2806bceb972f94a2ddaa9aa0`](https://github.com/plebioda/percona-server-mongodb/commit/30018a6eb35406fc2806bceb972f94a2ddaa9aa0) | SERVER-119792 Handle non-existent collections for rrid update/delete oplog entries (#48344) |
| [`888bac89586fb68783d8b70cd9633bef635f5429`](https://github.com/plebioda/percona-server-mongodb/commit/888bac89586fb68783d8b70cd9633bef635f5429) | SERVER-120044 Disable testing retryable findAndModify in ASC with PDIB enabled (#48396) |
| [`5244cf0a85845d895dd564c37680e658d7da3a73`](https://github.com/plebioda/percona-server-mongodb/commit/5244cf0a85845d895dd564c37680e658d7da3a73) | SERVER-117298: Add prometheus-cpp third-party library (#47013) |
| [`4f59c2a59ecdade6d21f92223b010f2a602513e1`](https://github.com/plebioda/percona-server-mongodb/commit/4f59c2a59ecdade6d21f92223b010f2a602513e1) | SERVER-120064 Prevent double append to `loadExtensions` in resmoke (#48413) |
| [`b063bfa515a1a8b4b5e9c766cae3ec4233a0da8b`](https://github.com/plebioda/percona-server-mongodb/commit/b063bfa515a1a8b4b5e9c766cae3ec4233a0da8b) | SERVER-115389 Implement Block Nested Loop Join as fallback (#46359) |
| [`0036427bfc481efd94db90ef2c76e99e6dd4ee4c`](https://github.com/plebioda/percona-server-mongodb/commit/0036427bfc481efd94db90ef2c76e99e6dd4ee4c) | SERVER-118428 Fix mongocryptd rejecting large messages (#48266) |
| [`688dee8bb2eeded5d22157ff24da5fa547e09e88`](https://github.com/plebioda/percona-server-mongodb/commit/688dee8bb2eeded5d22157ff24da5fa547e09e88) | SERVER-119981: Fix binDataClean() for deprecated type (#48347) |
| [`560b4f50a913bb8114bdf14916a12a7d7bbde97c`](https://github.com/plebioda/percona-server-mongodb/commit/560b4f50a913bb8114bdf14916a12a7d7bbde97c) | SERVER-120007 Complete TODO listed in SERVER-118709 (#48464) |
| [`9d070bd74b1fbf29cd6edc7ccd53f67a782749ce`](https://github.com/plebioda/percona-server-mongodb/commit/9d070bd74b1fbf29cd6edc7ccd53f67a782749ce) | SERVER-120045 Tag shard_drain_chunk_size_behavior.js with requires_fcv_83 to prevent multiversion errors (#48404) |
| [`1d41c69a5cd2374b7890f82431d8b48fee60c271`](https://github.com/plebioda/percona-server-mongodb/commit/1d41c69a5cd2374b7890f82431d8b48fee60c271) | SERVER-119410: Invoke a callback when setting breakpoints in VSCode editor (#48403) |
| [`4e1dc6972cf5a406d5524f718d35c3c6e729ba92`](https://github.com/plebioda/percona-server-mongodb/commit/4e1dc6972cf5a406d5524f718d35c3c6e729ba92) | SERVER-110340 Refine pre-image startup recovery for replicated truncates (#48237) |
| [`ac4148eee9e3ce5c27db1e563fae20b89973b83f`](https://github.com/plebioda/percona-server-mongodb/commit/ac4148eee9e3ce5c27db1e563fae20b89973b83f) | SERVER-120071 pauseBatchApplicationAfterWritingOplogEntries checks activation once (#48424) |
| [`6ee82dcff6c90db3853f6475e0b387d26da1c7ae`](https://github.com/plebioda/percona-server-mongodb/commit/6ee82dcff6c90db3853f6475e0b387d26da1c7ae) | SERVER-113916 Add query knobs for per subset level enumeration mode (#48143) |
| [`55472b711e1c30fe6159b56ce67f56eb211e5610`](https://github.com/plebioda/percona-server-mongodb/commit/55472b711e1c30fe6159b56ce67f56eb211e5610) | SERVER-118940 Record system resource usage under resmoke_suite_test (#48417) |
| [`bd001dece7a504005815974711eed151d87a1a39`](https://github.com/plebioda/percona-server-mongodb/commit/bd001dece7a504005815974711eed151d87a1a39) | Revert "SERVER-113184: Wait in initial sync for sync source to advance last c… (#46334)" (#48460) |
| [`fe3ad9e0d13de063d9f4d0f152392217b7aba90f`](https://github.com/plebioda/percona-server-mongodb/commit/fe3ad9e0d13de063d9f4d0f152392217b7aba90f) | SERVER-119992: Add evergreen_remote_exec expansion to linux-64-debug-required (#48356) |
| [`6b7306e471aed798b8d34ebb170185b1618d51e0`](https://github.com/plebioda/percona-server-mongodb/commit/6b7306e471aed798b8d34ebb170185b1618d51e0) | SERVER-115900 Allow remove_shard_util.js to use new shard removal API for transition to dedicated (#48384) |
| [`8b13939423f0aaf59c2739b7d883e6ecec1359c5`](https://github.com/plebioda/percona-server-mongodb/commit/8b13939423f0aaf59c2739b7d883e6ecec1359c5) | SERVER-96887 Create feature flag for Symmetric FCV (#48409) |
| [`2f580663ac918106e6c79bf804838e33b362d198`](https://github.com/plebioda/percona-server-mongodb/commit/2f580663ac918106e6c79bf804838e33b362d198) | SERVER-120049 Cleanup db_raii.cpp (#48398) |
| [`aaf89a8b00ed32607d3a42a169c0d658c3742f27`](https://github.com/plebioda/percona-server-mongodb/commit/aaf89a8b00ed32607d3a42a169c0d658c3742f27) | SERVER-110427 Update profiling data (#48433) |
| [`4b8a90d9f185fffc1309474039db08956c21f22e`](https://github.com/plebioda/percona-server-mongodb/commit/4b8a90d9f185fffc1309474039db08956c21f22e) | SERVER-119736 Populate rejectedPlans for join opt in explain (#48141) |
| [`14034e4971cc980846f5ab45a13b1cd0ddca070f`](https://github.com/plebioda/percona-server-mongodb/commit/14034e4971cc980846f5ab45a13b1cd0ddca070f) | SERVER-119199 Enable multi-router on tests that create timeseries collections on multiversion (#48244) |

</details>


# Merge Description

## Summary

This merge integrates a significant number of upstream commits from MongoDB. Key changes include updates to SASL authentication (PLAIN and SCRAM), replication initial sync logic, and various build system modifications. A merge conflict arose in the WiredTiger storage engine source file, which was resolved to preserve Percona-specific functionality.


## Auto-Merged Files

| File Path | Description |
|-----------|-------------|
| `sbom.json` | The Software Bill of Materials (SBOM) was automatically updated to reflect new and updated dependencies from the upstream MongoDB codebase. |
| `src/mongo/client/sasl_oidc_client_conversation.cpp` | Upstream modifications to the client-side SASL OIDC authentication conversation flow were merged. |
| `src/mongo/db/BUILD.bazel` | Build definitions were updated to incorporate new source files and dependencies from upstream. |
| `src/mongo/db/auth/BUILD.bazel` | Build definitions for the authentication module were updated, likely to include new files related to authentication enhancements. |
| `src/mongo/db/commands/BUILD.bazel` | Build system files for database commands were updated to reflect upstream changes. |
| `src/mongo/db/mongod_main.cpp` | Changes to the main server entry point were merged, likely related to new server options or initialization sequences from upstream. |
| `src/mongo/db/pipeline/BUILD.bazel` | Build definitions for the aggregation pipeline were updated to align with upstream modifications. |
| `src/mongo/db/server_options_server_helpers.cpp` | Upstream changes to server option parsing and handling helpers were integrated. |
| `src/mongo/db/storage/BUILD.bazel` | Build definitions for the storage module were updated to account for upstream file changes. |
| `src/mongo/db/storage/wiredtiger/BUILD.bazel` | Build definitions for the WiredTiger storage engine were updated to include new or changed source files from upstream. |
| `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp` | Non-conflicting changes from upstream were automatically merged. A conflict in the header include section was handled manually. |


## Review Notes

The primary conflict occurred in `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp`. The conflict was due to Percona-specific header includes (`encryption_keydb.h` and `wiredtiger_backup_cursor_hooks.h`) that are not present in the upstream version. The resolution was to keep these Percona-specific includes to maintain data-at-rest encryption and backup functionalities. Reviewers should verify that these features remain intact and that the surrounding authentication and replication changes from upstream have been integrated correctly.


<details>
<summary>Agent Stats</summary>


**Agent:** gemini_cli (version 0.29.0)



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| gemini-2.5-pro | 13944 | 595 | 0 | 1811 | 0 | 16350 |


</details>



# Conflict Context

- **Base Commit:** [`94b7881463eef7adea24ad163bb761bf96fbf112`](https://github.com/plebioda/percona-server-mongodb/commit/94b7881463eef7adea24ad163bb761bf96fbf112)
- **Ours Commit:** [`3e157a9357028ef70176eaf8a8abd8c1f0b255b0`](https://github.com/plebioda/percona-server-mongodb/commit/3e157a9357028ef70176eaf8a8abd8c1f0b255b0)
- **Theirs Commit:** [`61430ac26d642026f2755e9ceb129cae9f3852eb`](https://github.com/plebioda/percona-server-mongodb/commit/61430ac26d642026f2755e9ceb129cae9f3852eb)

## Conflicted Files

| Path | Conflict Type |
|------|---------------|
| `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp` | both modified |


<details>
<summary>Conflict details</summary>

## Their Commits

| Path | Commit | Message |
|------|--------|---------|
| `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp` | [`61430ac26d642026f2755e9ceb129cae9f3852eb`](https://github.com/plebioda/percona-server-mongodb/commit/61430ac26d642026f2755e9ceb129cae9f3852eb) | Revert "SERVER-101775 Journal flushes should not be susceptible to cache eviction stalls" (#48510) |
| `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp` | [`e1d3eaa85e02de7ddce8ae6f3ff8543bc84bfc94`](https://github.com/plebioda/percona-server-mongodb/commit/e1d3eaa85e02de7ddce8ae6f3ff8543bc84bfc94) | SERVER-117515 Trigger fastcount flush from Checkpointer (#48182) |

</details>



# Solutions

## Solution 1
### Summary

Resolved merge conflict in `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp` by merging `#include` directives. Kept Percona-specific headers for encryption and backup features, while respecting the removal of an unused header from the other branch.

**By:** Agent (gemini_cli v0.29.0)

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp` | Resolved a conflict in the `#include` section. Maintained the Percona-specific headers `encryption_keydb.h` and `wiredtiger_backup_cursor_hooks.h` from 'ours' and accepted the removal of the unused `wiredtiger_cache_eviction_opt_out_guard.h` from 'theirs'. |


### Unresolved Files

All conflicts have been resolved.


### Modified Files

No additional files were modified.


### Review Notes

The conflict in `wiredtiger_kv_engine.cpp` was a simple case of managing header includes. I verified that `wiredtiger_cache_eviction_opt_out_guard.h` was not used in the file before removing it, ensuring no functionality was broken.


<details>
<summary>Agent Stats</summary>


**Agent:** gemini_cli (version 0.29.0)



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| gemini-2.5-pro | 52742 | 281 | 43065 | 1692 | 0 | 54715 |


</details>



---

*note created with mergai 0.1.dev111+gc2eff4572.d20260220*
