### PR TITLE
Resolve conflicts for merge 'c3e45333645' into 'master'

### DIFF
--- a/README.third_party.md
+++ b/README.third_party.md
@@ -63,12 +63,7 @@ a notice will be included in
 | [re2]                                                | BSD-3-Clause                                   | 2025-08-05                               |                      | ✗                               |
 | [S2 Geometry Library]                                | Apache-2.0                                     | a25c502bda9d7e0274b9e2b7825fbddf13cc0306 | ✗                    | ✗                               |
 | [SafeInt]                                            | MIT                                            | 3.0.28a                                  |                      | ✗                               |
-<<<<<<< HEAD
-| [siphash]                                            | CC0-1.0, MIT, Apache 2.0 with LLVM exception   | f26d35e964c6290ffe23d9043475ad3129f409e0 |                      | ✗                               |
-||||||| b3b8da53ce7
-=======
 | [siphash]                                            | CC0-1.0, MIT, Apache 2.0 with LLVM exception   | eee7d0d84dc7731df2359b243aa5e75d85f6eaef |                      | ✗                               |
->>>>>>> c3e45333645ecb8e841065b8e47e803c5a7a59a6
 | [snappy]                                             | BSD-3-Clause                                   | 1.1.10                                   | ✗                    | ✗                               |
 | [Snowball Stemming Algorithms (libstemmer)]          | BSD-3-Clause                                   | 1.0.0                                    | ✗                    | ✗                               |
 | [tcmalloc]                                           | Apache-2.0                                     | f3b20f9a07e175c5d897df7b49d9830d4efa6110 |                      | ✗                               |
@@ -80,12 +75,7 @@ a notice will be included in
 | [zlib]                                               | Zlib                                           | 1.3.1                                    | ✗                    | ✗                               |
 | [Zstandard (zstd)]                                   | BSD-3-Clause OR GPL-2.0-only                   | 1.5.5                                    | ✗                    | ✗                               |
 
-<<<<<<< HEAD
 [AWS SDK for C++]: https://aws.amazon.com/sdk-for-cpp/
-||||||| b3b8da53ce7
-[AWS SDK for C++]: https://github.com/aws/aws-sdk-cpp.git
-=======
->>>>>>> c3e45333645ecb8e841065b8e47e803c5a7a59a6
 [Abseil Common Libraries (C++)]: https://github.com/abseil/abseil-cpp.git
 [Asio C++ Library]: https://github.com/chriskohlhoff/asio.git
 [Boost C++ Libraries]: https://github.com/boostorg/boost.git
@@ -130,12 +120,7 @@ a notice will be included in
 [pypi/ocspbuilder]: https://pypi.org/project/ocspbuilder/
 [pypi/ocspresponder]: https://pypi.org/project/ocspresponder/
 [re2]: https://github.com/google/re2.git
-<<<<<<< HEAD
-[siphash]: https://github.com/veorq/siphash/blob/f26d35e/
-||||||| b3b8da53ce7
-=======
 [siphash]: https://github.com/veorq/siphash/
->>>>>>> c3e45333645ecb8e841065b8e47e803c5a7a59a6
 [snappy]: https://github.com/google/tcmalloc.git
 [tcmalloc]: https://github.com/google/tcmalloc.git
 [timelib]: https://github.com/derickr/timelib.git

--- a/sbom.json
+++ b/sbom.json
@@ -2387,8 +2387,12 @@
           }
         ]
       },
-<<<<<<< HEAD
-      "scope": "excluded"
+      "properties": [
+        {
+          "name": "emits_persisted_data",
+          "value": "false"
+        }
+      ]
     },
     {
       "supplier": {
@@ -2482,132 +2486,11 @@
         ]
       },
       "scope": "required"
-||||||| b3b8da53ce7
-      "scope": "excluded"
-=======
-      "properties": [
-        {
-          "name": "emits_persisted_data",
-          "value": "false"
-        }
-      ]
->>>>>>> c3e45333645ecb8e841065b8e47e803c5a7a59a6
     }
   ],
   "dependencies": [
     {
-<<<<<<< HEAD
-      "ref": "pkg:github/mongodb/mongo@master",
-      "dependsOn": [
-        "pkg:github/abseil/abseil-cpp@20250512.1",
-        "pkg:github/arximboldi/immer@0b3aaf699b9d6f2e89f8e2b6d1221c307e02bda3",
-        "pkg:github/chriskohlhoff/asio@asio-1-34-2",
-        "pkg:github/google/benchmark@v1.5.2",
-        "pkg:github/boostorg/boost@boost-1.88.0",
-        "pkg:github/c-ares/c-ares@cares-1_27_0",
-        "pkg:github/cyrusimap/cyrus-sasl@cyrus-sasl-2.1.28",
-        "pkg:github/dcleblanc/safeint@3.0.28a",
-        "pkg:github/derickr/timelib@2022.13",
-        "pkg:github/fmtlib/fmt@11.2.0",
-        "pkg:github/facebook/folly@v2023.12.25.00",
-        "pkg:github/google/re2@2025-08-05",
-        "pkg:github/google/s2geometry@a25c502bda9d7e0274b9e2b7825fbddf13cc0306",
-        "pkg:github/google/snappy@1.1.10",
-        "pkg:github/google/fuzztest@v2025.07.28",
-        "pkg:github/google/googletest@v1.17.0",
-        "pkg:github/gperftools/gperftools@2.9.1",
-        "pkg:github/grpc/grpc@v1.74.1",
-        "pkg:github/unicode-org/icu@icu-release-57-1",
-        "pkg:generic/intel/IntelRDFPMathLib@2.0.1",
-        "pkg:github/jbeder/yaml-cpp@yaml-cpp-0.6.3",
-        "pkg:github/json-schema-org/json-schema-test-suite@728066f9c5c258ba3b1804a22a5b998f2ec77ec0",
-        "pkg:github/mongodb/libmongocrypt@1.15.0",
-        "pkg:github/libtom/libtomcrypt@v1.18.2",
-        "pkg:github/libunwind/libunwind@v1.8.1",
-        "pkg:github/antirez/linenoise@6cdc775807e57b2c3fd64bd207814f8ee1fe35f3",
-        "pkg:github/mongodb/mongo-c-driver@1.28.1",
-        "pkg:deb/debian/firefox-esr@140.7.0esr-1?arch=source",
-        "pkg:github/nodejs/node@22.1.0?download_url=https%3A%2F%2Fgithub.com%2Fnodejs%2Fnode%2Fblob%2F8b45c5d26a829bcd3280401dbc1874bcd1302289%2Fsrc%2Fnode_i18n.cc%23L825%23src%2Fnode_i18n.cc%3AGetStringWidth#src/node_i18n.cc",
-        "pkg:pypi/ocspbuilder@0.10.2",
-        "pkg:pypi/ocspresponder@0.5.0",
-        "pkg:github/pcre2project/pcre2@pcre2-10.40",
-        "pkg:github/protocolbuffers/protobuf@v6.31.1",
-        "pkg:github/roaringbitmap/croaring@v3.0.1",
-        "pkg:github/schemastore/schemastore@6847cfc3a17a04a7664474212db50c627e1e3408",
-        "pkg:github/aappleby/smhasher@a6bd3ce7be8ad147ea820a7cf6229a975c0c96bb",
-        "pkg:github/snowballstem/snowball@1.0.0",
-        "pkg:github/google/tcmalloc@f3b20f9a07e175c5d897df7b49d9830d4efa6110",
-        "pkg:generic/unicode-org/unicode@8.0.0",
-        "pkg:generic/valgrind/valgrind@093bef43d69236287ccc748591c9560a71181b0a",
-        "pkg:github/madler/zlib@1.3.1",
-        "pkg:github/facebook/zstd@v1.5.5",
-        "pkg:github/open-telemetry/opentelemetry-cpp@v1.24.0",
-        "pkg:github/open-telemetry/opentelemetry-proto@1.3.2",
-        "pkg:github/nlohmann/json@v3.11.3",
-        "pkg:github/wiredtiger/wiredtiger@12.0.0",
-        "pkg:github/davea42/libdwarf-code@libdwarf-2.1.0",
-        "pkg:github/jeremy-rifkin/cpptrace@v1.0.3",
-        "pkg:github/libarchive/libarchive@v3.8.4",
-        "pkg:github/aws/aws-sdk-cpp@1.11.471"
-      ]
-    },
-    {
-||||||| b3b8da53ce7
-      "ref": "pkg:github/mongodb/mongo@master",
-      "dependsOn": [
-        "pkg:github/abseil/abseil-cpp@20250512.1",
-        "pkg:github/arximboldi/immer@0b3aaf699b9d6f2e89f8e2b6d1221c307e02bda3",
-        "pkg:github/chriskohlhoff/asio@asio-1-34-2",
-        "pkg:github/google/benchmark@v1.5.2",
-        "pkg:github/boostorg/boost@boost-1.88.0",
-        "pkg:github/c-ares/c-ares@cares-1_27_0",
-        "pkg:github/cyrusimap/cyrus-sasl@cyrus-sasl-2.1.28",
-        "pkg:github/dcleblanc/safeint@3.0.28a",
-        "pkg:github/derickr/timelib@2022.13",
-        "pkg:github/fmtlib/fmt@11.2.0",
-        "pkg:github/facebook/folly@v2023.12.25.00",
-        "pkg:github/google/re2@2025-08-05",
-        "pkg:github/google/s2geometry@a25c502bda9d7e0274b9e2b7825fbddf13cc0306",
-        "pkg:github/google/snappy@1.1.10",
-        "pkg:github/google/fuzztest@v2025.07.28",
-        "pkg:github/google/googletest@v1.17.0",
-        "pkg:github/gperftools/gperftools@2.9.1",
-        "pkg:github/grpc/grpc@v1.74.1",
-        "pkg:github/unicode-org/icu@icu-release-57-1",
-        "pkg:generic/intel/IntelRDFPMathLib@2.0.1",
-        "pkg:github/jbeder/yaml-cpp@yaml-cpp-0.6.3",
-        "pkg:github/json-schema-org/json-schema-test-suite@728066f9c5c258ba3b1804a22a5b998f2ec77ec0",
-        "pkg:github/mongodb/libmongocrypt@1.15.0",
-        "pkg:github/libtom/libtomcrypt@v1.18.2",
-        "pkg:github/libunwind/libunwind@v1.8.1",
-        "pkg:github/antirez/linenoise@6cdc775807e57b2c3fd64bd207814f8ee1fe35f3",
-        "pkg:github/mongodb/mongo-c-driver@1.28.1",
-        "pkg:deb/debian/firefox-esr@140.7.0esr-1?arch=source",
-        "pkg:github/nodejs/node@22.1.0?download_url=https%3A%2F%2Fgithub.com%2Fnodejs%2Fnode%2Fblob%2F8b45c5d26a829bcd3280401dbc1874bcd1302289%2Fsrc%2Fnode_i18n.cc%23L825%23src%2Fnode_i18n.cc%3AGetStringWidth#src/node_i18n.cc",
-        "pkg:pypi/ocspbuilder@0.10.2",
-        "pkg:pypi/ocspresponder@0.5.0",
-        "pkg:github/pcre2project/pcre2@pcre2-10.40",
-        "pkg:github/protocolbuffers/protobuf@v6.31.1",
-        "pkg:github/roaringbitmap/croaring@v3.0.1",
-        "pkg:github/schemastore/schemastore@6847cfc3a17a04a7664474212db50c627e1e3408",
-        "pkg:github/aappleby/smhasher@a6bd3ce7be8ad147ea820a7cf6229a975c0c96bb",
-        "pkg:github/snowballstem/snowball@1.0.0",
-        "pkg:github/google/tcmalloc@f3b20f9a07e175c5d897df7b49d9830d4efa6110",
-        "pkg:generic/unicode-org/unicode@8.0.0",
-        "pkg:generic/valgrind/valgrind@093bef43d69236287ccc748591c9560a71181b0a",
-        "pkg:github/madler/zlib@1.3.1",
-        "pkg:github/facebook/zstd@v1.5.5",
-        "pkg:github/open-telemetry/opentelemetry-cpp@v1.24.0",
-        "pkg:github/open-telemetry/opentelemetry-proto@1.3.2",
-        "pkg:github/nlohmann/json@v3.11.3",
-        "pkg:github/wiredtiger/wiredtiger@12.0.0",
-        "pkg:github/davea42/libdwarf-code@libdwarf-2.1.0",
-        "pkg:github/jeremy-rifkin/cpptrace@v1.0.3"
-      ]
-    },
-    {
-=======
->>>>>>> c3e45333645ecb8e841065b8e47e803c5a7a59a6
+
       "ref": "pkg:deb/debian/firefox-esr@140.7.0esr-1?arch=source",
       "dependsOn": []
     },
@@ -2803,7 +2686,9 @@
         "pkg:github/veorq/siphash@eee7d0d84dc7731df2359b243aa5e75d85f6eaef",
         "pkg:github/wiredtiger/wiredtiger@12.0.0",
         "pkg:pypi/ocspbuilder@0.10.2",
-        "pkg:pypi/ocspresponder@0.5.0"
+        "pkg:pypi/ocspresponder@0.5.0",
+        "pkg:github/libarchive/libarchive@v3.8.4",
+        "pkg:github/aws/aws-sdk-cpp@1.11.471"
       ]
     },
     {


### PR DESCRIPTION
# Merge Info

- **Target Branch:** `master`
- **Target Branch SHA:** [`66c1cffce207f01bed011009fabeec8ab7cc2fc9`](https://github.com/plebioda/percona-server-mongodb/commit/66c1cffce207f01bed011009fabeec8ab7cc2fc9)
- **Merge Commit:** [`c3e45333645ecb8e841065b8e47e803c5a7a59a6`](https://github.com/plebioda/percona-server-mongodb/commit/c3e45333645ecb8e841065b8e47e803c5a7a59a6)


# Merge Context

- **Number of merged commits:** 1
- **Auto-merged files:** 3



## Auto-Merged Files


- `buildscripts/sbom_linter.py`

- `sbom.json`

- `src/third_party/README.md`



**Merged with strategy:** ort



<details>
<summary>Show details</summary>

| Commit | Summary |
|------------|---------|
| [`c3e45333645ecb8e841065b8e47e803c5a7a59a6`](https://github.com/plebioda/percona-server-mongodb/commit/c3e45333645ecb8e841065b8e47e803c5a7a59a6) | SERVER-116213, SERVER-117626, SERVER-117790: Enhance SBOM automation with private folder support, team automation and branch filtering (#48555) |

</details>


# Merge Description

## Summary

Merge upstream MongoDB changes updating third-party library versions (notably siphash) and synchronizing SBOM metadata.


## Auto-Merged Files

| File Path | Description |
|-----------|-------------|
| `buildscripts/sbom_linter.py` | Integrated upstream updates to the SBOM linting script for compatibility with new metadata formats. |
| `src/third_party/README.md` | Synchronized third-party component documentation with upstream library changes. |
| `sbom.json` | Merged upstream library metadata updates while resolving conflicts with Percona-specific additions. |


## Review Notes

Conflicts in README.third_party.md and sbom.json were resolved by prioritizing Percona-specific features (such as the libarchive 3.8.4 addition) and maintaining specific documentation URLs for AWS SDK. Upstream updates to siphash were integrated where compatible. Ensure MODULE.bazel.lock is regenerated by executing 'bazel query //... >/dev/null' following the resolution.


<details>
<summary>Agent Stats</summary>


**Agent:** gemini_cli (version 0.33.0)



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| gemini-3-flash-preview | 10146 | 213 | 0 | 2611 | 0 | 12970 |


</details>



# Conflict Context

- **Base Commit:** [`b3b8da53ce7b7801bf52059ad7347b5859d82840`](https://github.com/plebioda/percona-server-mongodb/commit/b3b8da53ce7b7801bf52059ad7347b5859d82840)
- **Ours Commit:** [`66c1cffce207f01bed011009fabeec8ab7cc2fc9`](https://github.com/plebioda/percona-server-mongodb/commit/66c1cffce207f01bed011009fabeec8ab7cc2fc9)
- **Theirs Commit:** [`c3e45333645ecb8e841065b8e47e803c5a7a59a6`](https://github.com/plebioda/percona-server-mongodb/commit/c3e45333645ecb8e841065b8e47e803c5a7a59a6)

## Conflicted Files

| Path | Conflict Type |
|------|---------------|
| `README.third_party.md` | both modified |
| `sbom.json` | both modified |


<details>
<summary>Conflict details</summary>

## Their Commits

| Path | Commit | Message |
|------|--------|---------|
| `README.third_party.md` | [`c3e45333645ecb8e841065b8e47e803c5a7a59a6`](https://github.com/plebioda/percona-server-mongodb/commit/c3e45333645ecb8e841065b8e47e803c5a7a59a6) | SERVER-116213, SERVER-117626, SERVER-117790: Enhance SBOM automation with private folder support, team automation and branch filtering (#48555) |
| `sbom.json` | [`c3e45333645ecb8e841065b8e47e803c5a7a59a6`](https://github.com/plebioda/percona-server-mongodb/commit/c3e45333645ecb8e841065b8e47e803c5a7a59a6) | SERVER-116213, SERVER-117626, SERVER-117790: Enhance SBOM automation with private folder support, team automation and branch filtering (#48555) |

</details>



# Solutions

## Solution 1
### Summary

Resolved merge conflicts in README.third_party.md and sbom.json. Updated siphash version to theirs (eee7d0d84dc7731df2359b243aa5e75d85f6eaef) and URL to generic form. Preserved Percona-specific entries (AWS SDK for C++, libarchive) in both files. Adopted theirs' structural change from scope to properties for ocspresponder component in sbom.json, and removed the old duplicate dependencies block while adding Percona-specific dependencies to the new auto-merged dependencies block.

**By:** Agent (opencode_cli v1.1.41)

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `README.third_party.md` | Resolved 3 conflict regions: (1) siphash table row - took theirs' updated version hash (eee7d0d84dc7731df2359b243aa5e75d85f6eaef); (2) AWS SDK for C++ URL reference - kept HEAD's Percona-specific entry with updated URL (https://aws.amazon.com/sdk-for-cpp/), which theirs deleted; (3) siphash URL reference - took theirs' generic URL (https://github.com/veorq/siphash/) instead of HEAD's commit-specific URL. |
| `sbom.json` | Resolved 2 conflict regions: (1) ocspresponder component ending - adopted theirs' structural change from 'scope: excluded' to a 'properties' array, while preserving Percona-specific libarchive and AWS SDK component entries; (2) dependencies block - removed the old duplicate dependencies block (theirs' approach) since a new auto-merged one already exists, and added Percona-specific dependency references (libarchive@v3.8.4, aws-sdk-cpp@1.11.471) to the new mongo@master dependsOn list. |


### Unresolved Files

All conflicts have been resolved.


### Modified Files

No additional files were modified.


### Review Notes

The siphash version was updated to theirs' version (eee7d0d) matching upstream MongoDB's update. Percona-specific entries (AWS SDK for C++, libarchive) were preserved in both README.third_party.md and sbom.json per Percona priority rules. In sbom.json, theirs restructured the ocspresponder component to use a properties array instead of scope field - this structural change was accepted while keeping Percona additions. The old-format duplicate dependencies block was removed (as theirs did) since the new auto-merged block at the end of the file already contains all MongoDB deps; Percona deps were added to this new block.


<details>
<summary>Agent Stats</summary>


**Agent:** opencode_cli (version 1.1.41)



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| anthropic/claude-opus-4-6 | 25 | 10206 |  |  |  |  |


</details>



---

*note created with mergai 0.1.dev111+gc2eff4572.d20260220*
