### PR TITLE
Resolve conflicts for merge 'ac6584f4061' into 'master'

### DIFF
--- a/jstests/libs/python.js
+++ b/jstests/libs/python.js
@@ -5,8 +5,7 @@ export function getPython3Binary() {
     // or else we will pick up a python that is not in our venv
     clearRawMongoProgramOutput();
     assert.eq(runNonMongoProgram("python", "--version"), 0);
-<<<<<<< HEAD
-    const pythonVersion = rawMongoProgramOutput("Python"); // Will look like "Python 3.10.4\n"
+    const pythonVersion = rawMongoProgramOutput("Python"); // Will look like "Python 3.13.4\n"
     // TODO(SERVER-117568): Remove Python 3.10 check after upgrade is complete
     const match = pythonVersion.match(/Python 3\.(\d+)\./);
     if (match && match[1] >= 10) {
@@ -16,18 +15,6 @@ export function getPython3Binary() {
         return "python";
     }
 
-||||||| 0115b2026da
-    const pythonVersion = rawMongoProgramOutput("Python"); // Will look like "Python 3.10.4\n"
-    // TODO(SERVER-117568): Remove Python 3.10 check after upgrade is complete
-    const usingPython310 = /Python 3\.10/.exec(pythonVersion);
-    if (usingPython310) {
-        jsTest.log.info("Found python 3.10 by default. Likely this is because we are using a virtual environment.");
-        return "python";
-    }
-
-=======
-    const pythonVersion = rawMongoProgramOutput("Python"); // Will look like "Python 3.13.4\n"
->>>>>>> ac6584f4061d8209fde5bd4ce7a6597f42d2196c
     const usingPython313 = /Python 3\.13/.exec(pythonVersion);
     if (usingPython313) {
         jsTest.log.info("Found python 3.13 by default. Likely this is because we are using a virtual environment.");

--- a/sbom.json
+++ b/sbom.json
@@ -2393,7 +2393,6 @@
           "value": "false"
         }
       ]
-<<<<<<< HEAD
     },
     {
       "supplier": {
@@ -2487,73 +2486,6 @@
         ]
       },
       "scope": "required"
-    },
-    {
-      "bom-ref": "pkg:github/apache/arrow-nanoarrow@apache-arrow-nanoarrow-0.7.0?package-id=614f3463351947a8",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "name": "github.com/apache/arrow-nanoarrow",
-      "purl": "pkg:github/apache/arrow-nanoarrow@apache-arrow-nanoarrow-0.7.0",
-      "type": "library",
-      "version": "apache-arrow-nanoarrow-0.7.0",
-      "scope": "excluded",
-      "properties": []
-    },
-    {
-      "bom-ref": "pkg:github/apache/iceberg-cpp@v0.2.0-rc1?package-id=ce0b9d2c8402061a",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "name": "github.com/apache/iceberg-cpp",
-      "purl": "pkg:github/apache/iceberg-cpp@v0.2.0-rc1",
-      "type": "library",
-      "version": "v0.2.0-rc1",
-      "scope": "excluded",
-      "properties": []
-||||||| 0115b2026da
-    },
-    {
-      "bom-ref": "pkg:github/apache/arrow-nanoarrow@apache-arrow-nanoarrow-0.7.0?package-id=614f3463351947a8",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "name": "github.com/apache/arrow-nanoarrow",
-      "purl": "pkg:github/apache/arrow-nanoarrow@apache-arrow-nanoarrow-0.7.0",
-      "type": "library",
-      "version": "apache-arrow-nanoarrow-0.7.0",
-      "scope": "excluded",
-      "properties": []
-    },
-    {
-      "bom-ref": "pkg:github/apache/iceberg-cpp@v0.2.0-rc1?package-id=ce0b9d2c8402061a",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "name": "github.com/apache/iceberg-cpp",
-      "purl": "pkg:github/apache/iceberg-cpp@v0.2.0-rc1",
-      "type": "library",
-      "version": "v0.2.0-rc1",
-      "scope": "excluded",
-      "properties": []
-=======
->>>>>>> ac6584f4061d8209fde5bd4ce7a6597f42d2196c
     }
   ],
   "dependencies": [
@@ -2813,7 +2745,6 @@
     {
       "ref": "pkg:pypi/ocspresponder@0.5.0",
       "dependsOn": []
-<<<<<<< HEAD
     },
     {
       "ref": "pkg:github/libarchive/libarchive@v3.8.4",
@@ -2824,25 +2755,6 @@
       "dependsOn": [
         "pkg:github/madler/zlib@v1.3.1"
       ]
-    },
-    {
-      "ref": "pkg:github/apache/arrow-nanoarrow@apache-arrow-nanoarrow-0.7.0?package-id=614f3463351947a8",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:github/apache/iceberg-cpp@v0.2.0-rc1?package-id=ce0b9d2c8402061a",
-      "dependsOn": []
-||||||| 0115b2026da
-    },
-    {
-      "ref": "pkg:github/apache/arrow-nanoarrow@apache-arrow-nanoarrow-0.7.0?package-id=614f3463351947a8",
-      "dependsOn": []
-    },
-    {
-      "ref": "pkg:github/apache/iceberg-cpp@v0.2.0-rc1?package-id=ce0b9d2c8402061a",
-      "dependsOn": []
-=======
->>>>>>> ac6584f4061d8209fde5bd4ce7a6597f42d2196c
     }
   ]
 }


### PR DESCRIPTION
# Merge Info

- **Target Branch:** `master`
- **Target Branch SHA:** [`a8e2faf282b6075699183fa4e8261f57932fc116`](https://github.com/plebioda/percona-server-mongodb/commit/a8e2faf282b6075699183fa4e8261f57932fc116)
- **Merge Commit:** [`ac6584f4061d8209fde5bd4ce7a6597f42d2196c`](https://github.com/plebioda/percona-server-mongodb/commit/ac6584f4061d8209fde5bd4ce7a6597f42d2196c)


# Merge Context

- **Number of merged commits:** 78
- **Auto-merged files:** 27



## Auto-Merged Files


- `BUILD.bazel`

- `MODULE.bazel.lock`

- `README.third_party.md`

- `bazel/config/BUILD.bazel`

- `bazel/wrapper_hook/autogenerated_targets.py`

- `bazel/wrapper_hook/wrapper_hook.py`

- `buildscripts/resmokeconfig/suites/ssl.yml`

- `jstests/auth/lib/commands_lib.js`

- `jstests/core/catalog/views/views_all_commands.js`

- `jstests/libs/python.js`

- `jstests/libs/write_concern_all_commands.js`

- `jstests/replsets/all_commands_downgrading_to_upgraded.js`

- `jstests/replsets/db_reads_while_recovering_all_commands.js`

- `jstests/sharding/all_commands_direct_shard_connection_auth.js`

- `jstests/sharding/database_versioning_all_commands.js`

- `jstests/sharding/read_write_concern_defaults_application.js`

- `jstests/sharding/safe_secondary_reads_drop_recreate.js`

- `jstests/sharding/safe_secondary_reads_single_migration_suspend_range_deletion.js`

- `jstests/sharding/safe_secondary_reads_single_migration_waitForDelete.js`

- `sbom.json`

- `src/mongo/db/BUILD.bazel`

- `src/mongo/db/auth/authorization_backend_local.cpp`

- `src/mongo/db/auth/authorization_manager_test.cpp`

- `src/mongo/db/commands/BUILD.bazel`

- `src/mongo/db/mongod_main.cpp`

- `src/mongo/db/namespace_string_reserved.h`

- `src/mongo/db/storage/BUILD.bazel`



**Merged with strategy:** ort



<details>
<summary>Show details</summary>

| Commit | Summary |
|------------|---------|
| [`ac6584f4061d8209fde5bd4ce7a6597f42d2196c`](https://github.com/plebioda/percona-server-mongodb/commit/ac6584f4061d8209fde5bd4ce7a6597f42d2196c) | Revert "SERVER-110181 BSON Custom Mutator for fuzztest (#48548)" (#49896) |
| [`d6d3f9bf9415ba62cf7942d1e5bbeb9811952b93`](https://github.com/plebioda/percona-server-mongodb/commit/d6d3f9bf9415ba62cf7942d1e5bbeb9811952b93) | SERVER-120810 Improve bazel-resmoke task generation (#49714) |
| [`d0f80baeaebac60bafb9f5d06408676547bafee5`](https://github.com/plebioda/percona-server-mongodb/commit/d0f80baeaebac60bafb9f5d06408676547bafee5) | SERVER-102815 SERVER-102816 Make refineCollectionShardKey DDL commit authoritative (#49407) |
| [`593ea298492798743e9fb00ba3834f5e5fe9bcb3`](https://github.com/plebioda/percona-server-mongodb/commit/593ea298492798743e9fb00ba3834f5e5fe9bcb3) | SERVER-120753 Disable failing tests on replicated fast count build variant (#49609) |
| [`e0d75ea633c1e3192360cb2d5b191e8a2053a557`](https://github.com/plebioda/percona-server-mongodb/commit/e0d75ea633c1e3192360cb2d5b191e8a2053a557) | SERVER-119737 Plan stability tests for join optimization (#49764) |
| [`f0124174bf68a694f03f62e6a3058d360a8ec271`](https://github.com/plebioda/percona-server-mongodb/commit/f0124174bf68a694f03f62e6a3058d360a8ec271) | SERVER-121986: Exclude agent dir from copybara (#49887) |
| [`a62ba86084c4aa9dc0bef0afe67be2dcc06781a9`](https://github.com/plebioda/percona-server-mongodb/commit/a62ba86084c4aa9dc0bef0afe67be2dcc06781a9) | SERVER-121918: Implement MacOS Cross Compilation with RBE (#49787) |
| [`14ad2a9d3fd48ee0567c2b81e0b16e2ab8464d72`](https://github.com/plebioda/percona-server-mongodb/commit/14ad2a9d3fd48ee0567c2b81e0b16e2ab8464d72) | SERVER-121871 RouterUptimeReporter does not wait its thread to join (#49811) |
| [`4b1f6bbbe86cdb0a8124668bccbc765401f61dd3`](https://github.com/plebioda/percona-server-mongodb/commit/4b1f6bbbe86cdb0a8124668bccbc765401f61dd3) | SERVER-121952 Add performance warning to internalMeasureQueryExecutionTimeInNanoseconds (#49879) |
| [`77ecd3b4bb84e847d8c1b22e6e1463bf4a2776e9`](https://github.com/plebioda/percona-server-mongodb/commit/77ecd3b4bb84e847d8c1b22e6e1463bf4a2776e9) | SERVER-121902 Exclude abort_rewrite_collection_basic.js from the config stepdown suite (#49878) |
| [`ed4b01d52bc5639581f1ee5001cc110597986980`](https://github.com/plebioda/percona-server-mongodb/commit/ed4b01d52bc5639581f1ee5001cc110597986980) | SERVER-120950 Make featureFlagExtensionsInsideHybridSearch an IFR flag (#49837) |
| [`9b10d6ab76f2c34edaaec469c2a5721772a91a72`](https://github.com/plebioda/percona-server-mongodb/commit/9b10d6ab76f2c34edaaec469c2a5721772a91a72) | SERVER-110181 BSON Custom Mutator for fuzztest (#48548) |
| [`41b446eae2062fb7c503e760a3fee970154ace6a`](https://github.com/plebioda/percona-server-mongodb/commit/41b446eae2062fb7c503e760a3fee970154ace6a) | SERVER-115423 Implement WASM bridge (#49359) |
| [`81be9aecb16335c38451b4f64925f6779054e800`](https://github.com/plebioda/percona-server-mongodb/commit/81be9aecb16335c38451b4f64925f6779054e800) | SERVER-120837 Builtin array (#49813) |
| [`254b6f3956405ae72d95a014488cfea1bf66bcb1`](https://github.com/plebioda/percona-server-mongodb/commit/254b6f3956405ae72d95a014488cfea1bf66bcb1) | SERVER-121905 Change LOGV2 when we can't read the diskspace from a directory to a LOGV2_WARNING (#49825) |
| [`2116b6f356c9ae51aa2c1f040b5cf2d1ac12d4a7`](https://github.com/plebioda/percona-server-mongodb/commit/2116b6f356c9ae51aa2c1f040b5cf2d1ac12d4a7) | SERVER-115986 Persist stats across write conflict retries (#49752) |
| [`05532e05eea92f809b7ea954d1bc7dae4808c6c3`](https://github.com/plebioda/percona-server-mongodb/commit/05532e05eea92f809b7ea954d1bc7dae4808c6c3) | SERVER-119289: Convert clusterBulkWrite to TypedCommand (#49426) |
| [`c284637bd1d7e736aaab16a8b8883a905f772803`](https://github.com/plebioda/percona-server-mongodb/commit/c284637bd1d7e736aaab16a8b8883a905f772803) | SERVER-121960 Make `WriteUnitOfWork::_isGroupingOplogEntries` public (#49866) |
| [`2c554dd99bfdfc011233014583365175579ad06e`](https://github.com/plebioda/percona-server-mongodb/commit/2c554dd99bfdfc011233014583365175579ad06e) | SERVER-115901 Add support of new remove_shard API to add_remove_shards.py (#47846) |
| [`8040a49f1a29126537505c6ee6230ad87fb74569`](https://github.com/plebioda/percona-server-mongodb/commit/8040a49f1a29126537505c6ee6230ad87fb74569) | SERVER-121407 Enable viewless timeseries feature flag in fcv_upgrade_downgrade_primary_step_down_passthrough suite (#49831) |
| [`8ad8d1fba44245ce5e0a6473aae884c1bf2303d6`](https://github.com/plebioda/percona-server-mongodb/commit/8ad8d1fba44245ce5e0a6473aae884c1bf2303d6) | SERVER-120396 Restart vector_search_extension tests (#49854) |
| [`fb02340a5b7022925f2b5db98d47e9a48d789ef0`](https://github.com/plebioda/percona-server-mongodb/commit/fb02340a5b7022925f2b5db98d47e9a48d789ef0) | SERVER-121827 Join optimization: a plan stability test for the official TPC-H queries (#49757) |
| [`664f671f3f76f7cb42ddb731ea1c50741a665bd5`](https://github.com/plebioda/percona-server-mongodb/commit/664f671f3f76f7cb42ddb731ea1c50741a665bd5) | SERVER-120476: Fix cursor.ns to return requested namespace instead of internal resolved namespace (#48738) |
| [`5e9934e133d611e2d4c2ea494c5cf717484a56bf`](https://github.com/plebioda/percona-server-mongodb/commit/5e9934e133d611e2d4c2ea494c5cf717484a56bf) | SERVER-121961: Fix TTL unit test docsExamined (#49864) |
| [`474a93099f78d21174d85b25529c9e0462c323dd`](https://github.com/plebioda/percona-server-mongodb/commit/474a93099f78d21174d85b25529c9e0462c323dd) | SERVER-121955: Find evergreen binary using shutil.which() in yamllinters.py (#49859) |
| [`e108601ce88e51bc1a1df8a5f96dd4ad722f056d`](https://github.com/plebioda/percona-server-mongodb/commit/e108601ce88e51bc1a1df8a5f96dd4ad722f056d) | SERVER-121906: remove deleted disable flags that were missed (#49827) |
| [`33ae6b4dc9156d4ba239bfc1a0b570aa743294c6`](https://github.com/plebioda/percona-server-mongodb/commit/33ae6b4dc9156d4ba239bfc1a0b570aa743294c6) | SERVER-121832: Increase host size (#49711) |
| [`388a35f4dde0e1263a994c0a9638c620e3147ebc`](https://github.com/plebioda/percona-server-mongodb/commit/388a35f4dde0e1263a994c0a9638c620e3147ebc) | SERVER-99482 Extend checkMetadataConsistency to validate that each shard is aware of the chunks it owns (#49309) |
| [`eec5012003c2f960c19ec678b3a14d04382023c4`](https://github.com/plebioda/percona-server-mongodb/commit/eec5012003c2f960c19ec678b3a14d04382023c4) | SERVER-121903 avoid floating point UDLs (#49838) |
| [`0d3604e26438f860880c7428ec59e10da942abd0`](https://github.com/plebioda/percona-server-mongodb/commit/0d3604e26438f860880c7428ec59e10da942abd0) | SERVER-121924 Strengthen assertions in timeseries_raw_data_queries.js (#49845) |
| [`e7be6505898a022d276e31111fb3e7ece2c03299`](https://github.com/plebioda/percona-server-mongodb/commit/e7be6505898a022d276e31111fb3e7ece2c03299) | SERVER-121829 Track extra fetches performed by write stages (#49753) |
| [`80b12c6b63f1769bb187a50580018037945ffa78`](https://github.com/plebioda/percona-server-mongodb/commit/80b12c6b63f1769bb187a50580018037945ffa78) | SERVER-121890 Update etc/extensions.yml for mongot-extension v1.0.0 (#49826) |
| [`a35aea179ce05fd12bc7be5fe17c021ac33f4cee`](https://github.com/plebioda/percona-server-mongodb/commit/a35aea179ce05fd12bc7be5fe17c021ac33f4cee) | SERVER-119757 Rename ShardingDDLCoordinator to ShardingCoordinator (#48662) |
| [`d19fd91974abee8b225ffc0fe5d202baaf15d6c6`](https://github.com/plebioda/percona-server-mongodb/commit/d19fd91974abee8b225ffc0fe5d202baaf15d6c6) | SERVER-111575 Improve debuggability of the shard registry (#47400) |
| [`0518a1b5aa4458484d0bccb94e2caf7ae0b4f81a`](https://github.com/plebioda/percona-server-mongodb/commit/0518a1b5aa4458484d0bccb94e2caf7ae0b4f81a) | SERVER-120174 Ensure 'bits' index parameter is stored as integer type on-disk (#48531) |
| [`53a0fec37a825c0e956ff748c4f8e5319dffbdf4`](https://github.com/plebioda/percona-server-mongodb/commit/53a0fec37a825c0e956ff748c4f8e5319dffbdf4) | SERVER-121833: Fix double-accounting of write conflicts in Classic engine (#49761) |
| [`57bfede16c0d3e761cf5fc3daec4772572b66041`](https://github.com/plebioda/percona-server-mongodb/commit/57bfede16c0d3e761cf5fc3daec4772572b66041) | SERVER-121703 Implement clearFilteringMetadata command (#49653) |
| [`392731e0ae573a9ccfd83bcf3a36b7d77b356277`](https://github.com/plebioda/percona-server-mongodb/commit/392731e0ae573a9ccfd83bcf3a36b7d77b356277) | SERVER-110427 Update profiling data (#49844) |
| [`3f80e17f4c742f116ae29cbfe8543a8200fb4f18`](https://github.com/plebioda/percona-server-mongodb/commit/3f80e17f4c742f116ae29cbfe8543a8200fb4f18) | SERVER-102519 Remove old shard catalog authoritative collection references (#49463) |
| [`a5eadf495e0991d165c09584e00bc348a946c719`](https://github.com/plebioda/percona-server-mongodb/commit/a5eadf495e0991d165c09584e00bc348a946c719) | SERVER-111381 Implement shard targeter for ALL DATABASES (#49554) |
| [`3542b0ed3ef59f1db53a7aa9ff9dacc20b594db3`](https://github.com/plebioda/percona-server-mongodb/commit/3542b0ed3ef59f1db53a7aa9ff9dacc20b594db3) | SERVER-121919 Allow SERVER -XXXX tickets to pass through PR title validator in PR status check (#49839) |
| [`0107dc33e869c9eea3a2476ee8cc71532bb61e89`](https://github.com/plebioda/percona-server-mongodb/commit/0107dc33e869c9eea3a2476ee8cc71532bb61e89) | SERVER-112416 FCV Support for LDAP/OIDC internal authz (#47626) |
| [`4997d2ca49171f09a47f9f34945fd3ead6481279`](https://github.com/plebioda/percona-server-mongodb/commit/4997d2ca49171f09a47f9f34945fd3ead6481279) | SERVER-121785 Add a passthrough test for split+move+merge chunks on timeseries collections (#49721) |
| [`3634a70cf50568d5b4a8ee2c6856dc46f2bfb2f3`](https://github.com/plebioda/percona-server-mongodb/commit/3634a70cf50568d5b4a8ee2c6856dc46f2bfb2f3) | SERVER-121793: prettier-format README files (#49712) |
| [`87dede76a6c25650035372d06c4f463140a6ec96`](https://github.com/plebioda/percona-server-mongodb/commit/87dede76a6c25650035372d06c4f463140a6ec96) | SERVER-121775: prettier-format .d.ts files (#49701) |
| [`5490094a267d24bb7cdb990d91ff7f464d5a81c7`](https://github.com/plebioda/percona-server-mongodb/commit/5490094a267d24bb7cdb990d91ff7f464d5a81c7) | SERVER-121260 Fix server_status_cbr.js test for histogram output changes (#49822) |
| [`e8cf205d0bf46053a1bd5b3d31e783afc7c2251b`](https://github.com/plebioda/percona-server-mongodb/commit/e8cf205d0bf46053a1bd5b3d31e783afc7c2251b) | SERVER-121511: Update remaining Python 3.10 references to 3.13 (#49522) |
| [`fb291a9a9e26b6846b45ff9d68dee26455e17b26`](https://github.com/plebioda/percona-server-mongodb/commit/fb291a9a9e26b6846b45ff9d68dee26455e17b26) | SERVER-121406 Enable viewless timeseries feature flag in sharding_stepdown_fcv_upgrade_downgrade_jscore suite (#49406) |
| [`0201e895beab813d9f0164d7135b9ac696d4f05a`](https://github.com/plebioda/percona-server-mongodb/commit/0201e895beab813d9f0164d7135b9ac696d4f05a) | SERVER-120247 Add test coverage for collStats on timeseries collections during FCV upgrade/downgrade (#49534) |
| [`94b1b630ca44bce03cd1d5ce6d186f2f5221be9e`](https://github.com/plebioda/percona-server-mongodb/commit/94b1b630ca44bce03cd1d5ce6d186f2f5221be9e) | SERVER-120944 Unit test ensureSufficientDiskSpaceForSpilling (#49705) |
| [`0d79f092eadaf98ec1b6ecf125b1613c3a6aaae8`](https://github.com/plebioda/percona-server-mongodb/commit/0d79f092eadaf98ec1b6ecf125b1613c3a6aaae8) | SERVER-121453: Convert mongod distinct command to TypedCommand (#49337) |
| [`7926ed1c06149c953b1053a9edba307fd1a99b2e`](https://github.com/plebioda/percona-server-mongodb/commit/7926ed1c06149c953b1053a9edba307fd1a99b2e) | SERVER-121883 Limit batch size bytes when loading into index for PDIB (#49800) |
| [`e73212eb1ebd6536686a615d8f74978e063b0ada`](https://github.com/plebioda/percona-server-mongodb/commit/e73212eb1ebd6536686a615d8f74978e063b0ada) | Revert "SERVER-120837 Make SBE builtin array functions use Value RAII types (#49699)" (#49816) |
| [`52cd8758bc998298bfe42bf50e72698fcad15fef`](https://github.com/plebioda/percona-server-mongodb/commit/52cd8758bc998298bfe42bf50e72698fcad15fef) | SERVER-121821 Load test certs separately for macOS on ssl_modes_not_disabled_ingress.js (#49788) |
| [`9e8e55229c99b3256594548e7811e02c8dbd9a61`](https://github.com/plebioda/percona-server-mongodb/commit/9e8e55229c99b3256594548e7811e02c8dbd9a61) | SERVER-120986 Modularize ShardingDDLCoordinator OperationSessionInfo (#49458) |
| [`9a4548da1b1b3d41bf2e35346c734925093893b9`](https://github.com/plebioda/percona-server-mongodb/commit/9a4548da1b1b3d41bf2e35346c734925093893b9) | SERVER-121880 Relax buckets check in timeseries_reopened_bucket_insert.js test (#49794) |
| [`3f02dafeb26a6a705ef69c321cb85bc49703119b`](https://github.com/plebioda/percona-server-mongodb/commit/3f02dafeb26a6a705ef69c321cb85bc49703119b) | SERVER-111072 Auto-generated SBOM files [master] (#49747) |
| [`4ddb25a02441642d3a2805c3f08577c440bc6e7f`](https://github.com/plebioda/percona-server-mongodb/commit/4ddb25a02441642d3a2805c3f08577c440bc6e7f) | SERVER-121260 Change output format of HistogramServerStatusMetric (#49373) |
| [`7fbd72d6f0e4b2141ceeabb92563c9b484bd8603`](https://github.com/plebioda/percona-server-mongodb/commit/7fbd72d6f0e4b2141ceeabb92563c9b484bd8603) | SERVER-117726 move compiledb generation into the bazel graph (#49797) |
| [`04b80e7822044c22a1bd5204abb0c212140de7c3`](https://github.com/plebioda/percona-server-mongodb/commit/04b80e7822044c22a1bd5204abb0c212140de7c3) | SERVER-120620 FixedString C++20 (#49602) |
| [`5057e4bad7c0791c7629184783aa18328acb0dfc`](https://github.com/plebioda/percona-server-mongodb/commit/5057e4bad7c0791c7629184783aa18328acb0dfc) | SERVER-120288 Add early return guard in TrafficRecorder::observe() before BSON serialization (#48663) |
| [`4c9de70e1da5e30be6babd2ec221e4b6e6facfe6`](https://github.com/plebioda/percona-server-mongodb/commit/4c9de70e1da5e30be6babd2ec221e4b6e6facfe6) | SERVER-120625 Implement LPDS::isScored/isRanked/isSelection for future hybrid search validation (#49217) |
| [`67d49e46eda5d1c7d8d7ca6c1b6f0bcd5daf0904`](https://github.com/plebioda/percona-server-mongodb/commit/67d49e46eda5d1c7d8d7ca6c1b6f0bcd5daf0904) | SERVER-119298: disable streams everywhere unless flag is present (#48696) |
| [`0adf06d3945221f0d92aa8a64836edebcfdd076b`](https://github.com/plebioda/percona-server-mongodb/commit/0adf06d3945221f0d92aa8a64836edebcfdd076b) | SERVER-115428 Remove todo (#49763) |
| [`458c0617f1beb09f9e587ccd748fe420aa152d43`](https://github.com/plebioda/percona-server-mongodb/commit/458c0617f1beb09f9e587ccd748fe420aa152d43) | SERVER-119264: Convert clusterAggregate commands to TypedCommand (#49139) |
| [`49073adcd02dd398b40f3aaf7a3bd99cae8118bb`](https://github.com/plebioda/percona-server-mongodb/commit/49073adcd02dd398b40f3aaf7a3bd99cae8118bb) | SERVER-121882: Fix missing return statement in get_git_file_content retry path (#49795) |
| [`db91064f0ddc156aa6424276a4a7b031223b3d74`](https://github.com/plebioda/percona-server-mongodb/commit/db91064f0ddc156aa6424276a4a7b031223b3d74) | SERVER-121289 Make timeseries create path idempotent and concurrency safe (#49329) |
| [`a954de0618a49cd236288249cd3f4c3eb7fa81c6`](https://github.com/plebioda/percona-server-mongodb/commit/a954de0618a49cd236288249cd3f4c3eb7fa81c6) | SERVER-121751: Implement renames for $alwaysBoolean MatchExpressions (#49695) |
| [`1812b6d550503580be9cf84de1eb60ff326f32f6`](https://github.com/plebioda/percona-server-mongodb/commit/1812b6d550503580be9cf84de1eb60ff326f32f6) | SERVER-121755: Migrate rhel8-debug-aubsan-lite_fuzzer (#49677) |
| [`7241888b25c6a5532f241c7c36f47c2a173d6f27`](https://github.com/plebioda/percona-server-mongodb/commit/7241888b25c6a5532f241c7c36f47c2a173d6f27) | SERVER-121825 Make background operations bypass max queue length check (#49765) |
| [`6110a2c6e59858a582277959868cc5c572bf0d78`](https://github.com/plebioda/percona-server-mongodb/commit/6110a2c6e59858a582277959868cc5c572bf0d78) | SERVER-120837 Make SBE builtin array functions use Value RAII types (#49699) |
| [`625c8cc4d3b7783760915cf6addb1f3cb7ad80e1`](https://github.com/plebioda/percona-server-mongodb/commit/625c8cc4d3b7783760915cf6addb1f3cb7ad80e1) | SERVER-120163 Add serialization/deserialization for join hinting (#49308) |
| [`693299eb8ca7a7b411b4e090764aa36608a9780e`](https://github.com/plebioda/percona-server-mongodb/commit/693299eb8ca7a7b411b4e090764aa36608a9780e) | SERVER-119893 Remove uses of writeConflictRetry from validate repair (#49616) |
| [`d2422987898296fa81ada5ca071c4566dd808320`](https://github.com/plebioda/percona-server-mongodb/commit/d2422987898296fa81ada5ca071c4566dd808320) | SERVER-121861: Add B&V leads to code lockdown (#49776) |
| [`79b7c2ab968a4b0aa91616ebef294c90254295bd`](https://github.com/plebioda/percona-server-mongodb/commit/79b7c2ab968a4b0aa91616ebef294c90254295bd) | SERVER-119295: Convert explain command to TypedCommand (#48793) |
| [`5f63dfaead79f2e3ba5cc7d3d718c76ced8f179c`](https://github.com/plebioda/percona-server-mongodb/commit/5f63dfaead79f2e3ba5cc7d3d718c76ced8f179c) | SERVER-121287 Mark resharding operations under the critical section as non-deprioritizable (#49650) |
| [`61526273dcd21cf78a5c4172340766761e2a64f2`](https://github.com/plebioda/percona-server-mongodb/commit/61526273dcd21cf78a5c4172340766761e2a64f2) | SERVER-121851 Handle empty pipelines on views in $rankFusion and $scoreFusion (#49769) |
| [`8718c94babc4d8ef14b70c05e507fecb2eae4f78`](https://github.com/plebioda/percona-server-mongodb/commit/8718c94babc4d8ef14b70c05e507fecb2eae4f78) | SERVER-121728 Add `CLAUDE.md` to `mongo/db/extension` (#49685) |

</details>


# Merge Description

## Summary

Merge of 76 upstream MongoDB commits including Python version detection updates, SBOM library changes (removal of arrow-nanoarrow and iceberg-cpp), and various test/build configuration updates. The merge conflicts arise because PSMDB has enhanced Python version detection (supporting 3.10+) and added Percona-specific SBOM entries (libarchive, AWS SDK) that upstream doesn't have.


## Auto-Merged Files

| File Path | Description |
|-----------|-------------|
| `BUILD.bazel` | Build configuration changes merged automatically without conflicts |
| `MODULE.bazel.lock` | Bazel module lock file auto-merged (may need regeneration via bazel query) |
| `README.third_party.md` | Third-party documentation updates merged |
| `bazel/config/BUILD.bazel` | Bazel config changes merged |
| `bazel/wrapper_hook/autogenerated_targets.py` | Bazel wrapper hook changes merged |
| `bazel/wrapper_hook/wrapper_hook.py` | Bazel wrapper hook changes merged |
| `buildscripts/resmokeconfig/suites/ssl.yml` | SSL test suite configuration merged |
| `jstests/auth/lib/commands_lib.js` | Auth command library test updates merged |
| `jstests/core/catalog/views/views_all_commands.js` | Views commands test updates merged |
| `jstests/libs/write_concern_all_commands.js` | Write concern test library merged |
| `jstests/replsets/all_commands_downgrading_to_upgraded.js` | Replica set FCV test updates merged |
| `jstests/replsets/db_reads_while_recovering_all_commands.js` | Recovery reads test updates merged |
| `jstests/sharding/all_commands_direct_shard_connection_auth.js` | Sharding auth test updates merged |
| `jstests/sharding/database_versioning_all_commands.js` | Database versioning test updates merged |
| `jstests/sharding/read_write_concern_defaults_application.js` | Read/write concern defaults test merged |
| `jstests/sharding/safe_secondary_reads_drop_recreate.js` | Secondary reads test updates merged |
| `jstests/sharding/safe_secondary_reads_single_migration_suspend_range_deletion.js` | Migration test updates merged |
| `jstests/sharding/safe_secondary_reads_single_migration_waitForDelete.js` | Migration waitForDelete test merged |
| `src/mongo/db/BUILD.bazel` | Database module build config merged |
| `src/mongo/db/auth/authorization_backend_local.cpp` | Authorization backend changes merged |
| `src/mongo/db/auth/authorization_manager_test.cpp` | Authorization manager test updates merged |
| `src/mongo/db/commands/BUILD.bazel` | Commands module build config merged |
| `src/mongo/db/mongod_main.cpp` | Main mongod entry point changes merged |
| `src/mongo/db/namespace_string_reserved.h` | Reserved namespace string updates merged |
| `src/mongo/db/storage/BUILD.bazel` | Storage module build config merged |


## Review Notes

Two files require conflict resolution: (1) jstests/libs/python.js - PSMDB has enhanced Python 3.10+ detection while upstream updated comments to reference Python 3.13; keep PSMDB's enhanced version check logic while updating comment references if appropriate. (2) sbom.json - PSMDB added Percona-specific dependencies (libarchive, AWS SDK for C++) while upstream removed arrow-nanoarrow and iceberg-cpp; preserve all Percona additions and follow upstream's removal of the arrow/iceberg entries that aren't Percona-specific. After resolving conflicts, remember to run 'bazel query //... >/dev/null' to regenerate MODULE.bazel.lock.


<details>
<summary>Agent Stats</summary>


**Agent:** claude_cli (version 2.1.85 (Claude Code))



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| claude-opus-4-5 | 18 | 2137 |  |  |  |  |


</details>



# Conflict Context

- **Base Commit:** [`0115b2026dac3a22cb24e28e1eebf988f5c2f5b5`](https://github.com/plebioda/percona-server-mongodb/commit/0115b2026dac3a22cb24e28e1eebf988f5c2f5b5)
- **Ours Commit:** [`a8e2faf282b6075699183fa4e8261f57932fc116`](https://github.com/plebioda/percona-server-mongodb/commit/a8e2faf282b6075699183fa4e8261f57932fc116)
- **Theirs Commit:** [`ac6584f4061d8209fde5bd4ce7a6597f42d2196c`](https://github.com/plebioda/percona-server-mongodb/commit/ac6584f4061d8209fde5bd4ce7a6597f42d2196c)

## Conflicted Files

| Path | Conflict Type |
|------|---------------|
| `jstests/libs/python.js` | both modified |
| `sbom.json` | both modified |


<details>
<summary>Conflict details</summary>

## Their Commits

| Path | Commit | Message |
|------|--------|---------|
| `jstests/libs/python.js` | [`e8cf205d0bf46053a1bd5b3d31e783afc7c2251b`](https://github.com/plebioda/percona-server-mongodb/commit/e8cf205d0bf46053a1bd5b3d31e783afc7c2251b) | SERVER-121511: Update remaining Python 3.10 references to 3.13 (#49522) |
| `sbom.json` | [`3f02dafeb26a6a705ef69c321cb85bc49703119b`](https://github.com/plebioda/percona-server-mongodb/commit/3f02dafeb26a6a705ef69c321cb85bc49703119b) | SERVER-111072 Auto-generated SBOM files [master] (#49747) |

</details>



# Solutions

## Solution 1
### Summary

Resolved merge conflicts in jstests/libs/python.js and sbom.json by preserving Percona-specific changes while incorporating upstream Python version updates

**By:** Agent (claude_cli v2.1.85 (Claude Code))

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `jstests/libs/python.js` | Merged the flexible Python 3.10+ version check from Percona (ours) with the updated comment reflecting Python 3.13 from upstream (theirs). The Percona change generalizes the check to work with Python 3.10 and above, making it forward-compatible. |
| `sbom.json` | Preserved Percona-specific third-party entries (libarchive and AWS SDK for C++) in both components and dependencies sections. Followed upstream's removal of nanoarrow and iceberg-cpp entries since those are not Percona-specific features. |


### Unresolved Files

All conflicts have been resolved.


### Modified Files

No additional files were modified.


### Review Notes

The Python version check now handles any Python 3.10+ version via regex capture group comparison, which is more maintainable than hard-coded version checks. The sbom.json keeps Percona dependencies (libarchive for backup/restore, AWS SDK for cloud integration) while adopting upstream's cleanup of excluded components.


<details>
<summary>Agent Stats</summary>


**Agent:** claude_cli (version 2.1.85 (Claude Code))



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| claude-opus-4-5 | 58 | 6347 |  |  |  |  |


</details>



---

*note created with mergai 0.1.dev111+gc2eff4572.d20260220*
