### PR TITLE
Resolve conflicts for merge '650d9f458c5' into 'merging-master'

### DIFF
--- a/sbom.json
+++ b/sbom.json
@@ -25,13 +25,6 @@
       "group": "percona",
       "name": "percona-server-mongodb",
       "version": "master",
-<<<<<<< HEAD
-      "cpe": "cpe:2.3:a:percona:percona-server-mongodb:master:*:*:*:*:*:*:*",
-      "purl": "pkg:github/percona/percona-server-mongodb@master",
-||||||| a198be080de
-      "cpe": "cpe:2.3:a:mongodb:mongodb:master:*:*:*:*:*:*:*",
-      "purl": "pkg:github/mongodb/mongo@master",
-=======
       "description": "The MongoDB Database",
       "licenses": [
         {
@@ -47,9 +40,8 @@
           }
         }
       ],
-      "cpe": "cpe:2.3:a:mongodb:mongodb:master:*:*:*:*:*:*:*",
-      "purl": "pkg:github/mongodb/mongo@master",
->>>>>>> 650d9f458c5aeb3ec4f0ad960b77a566e3932b3f
+      "cpe": "cpe:2.3:a:percona:percona-server-mongodb:master:*:*:*:*:*:*:*",
+      "purl": "pkg:github/percona/percona-server-mongodb@master",
       "externalReferences": [
         {
           "url": "https://raw.githubusercontent.com/percona/percona-server-mongodb/refs/heads/master/LICENSE-Community.txt",
@@ -74,20 +66,7 @@
     "supplier": {
       "name": "Percona LLC",
       "url": [
-<<<<<<< HEAD
         "https://percona.com"
-||||||| a198be080de
-        "https://mongodb.com"
-      ]
-    },
-    "tools": {
-      "services": [
-        {
-          "name": "Endor Labs Inc",
-          "version": "v1.7.968"
-        }
-=======
-        "https://mongodb.com"
       ]
     },
     "tools": {
@@ -96,7 +75,6 @@
           "name": "Endor Labs Inc",
           "version": "v1.7.973"
         }
->>>>>>> 650d9f458c5aeb3ec4f0ad960b77a566e3932b3f
       ]
     }
   },


### PR DESCRIPTION
# Merge Info

- **Target Branch:** `merging-master`
- **Target Branch SHA:** [`8c1f7806050aaca37493caee638c5fc616bf02e3`](https://github.com/plebioda/percona-server-mongodb/commit/8c1f7806050aaca37493caee638c5fc616bf02e3)
- **Merge Commit:** [`650d9f458c5aeb3ec4f0ad960b77a566e3932b3f`](https://github.com/plebioda/percona-server-mongodb/commit/650d9f458c5aeb3ec4f0ad960b77a566e3932b3f)


# Merge Context

- **Number of merged commits:** 76
- **Auto-merged files:** 6


## Important Files Modified

- `src/mongo/db/audit.h`




## Auto-Merged Files


- `sbom.json`

- `src/mongo/base/error_codes.yml`

- `src/mongo/db/BUILD.bazel`

- `src/mongo/db/index_builds/BUILD.bazel`

- `src/mongo/db/mongod_main.cpp`

- `src/mongo/db/pipeline/BUILD.bazel`



**Merged with strategy:** ort




<details>
<summary>Show details</summary>

| Commit | Summary |
|------------|---------|
| [`650d9f458c5aeb3ec4f0ad960b77a566e3932b3f`](https://github.com/plebioda/percona-server-mongodb/commit/650d9f458c5aeb3ec4f0ad960b77a566e3932b3f) | SERVER-111072 Auto-generated SBOM files [master] (#54314) |
| [`dcefbaa8657ab0a184478488da3c92ae998278ef`](https://github.com/plebioda/percona-server-mongodb/commit/dcefbaa8657ab0a184478488da3c92ae998278ef) | SERVER-127282: Handle open-ended date IXSCAN bounds in plan_stability reconstruction (#54145) |
| [`989847bc894a0806b35ac818dfeb608b455d8c67`](https://github.com/plebioda/percona-server-mongodb/commit/989847bc894a0806b35ac818dfeb608b455d8c67) | SERVER-125838 Test extension match and project pushdown rules (#54043) |
| [`e2917819ab5bd6d6d8291e67deaabe3a12cb62f5`](https://github.com/plebioda/percona-server-mongodb/commit/e2917819ab5bd6d6d8291e67deaabe3a12cb62f5) | Revert "SERVER-127291: $iceberg dynamic routing for tableName (#54053)" (#54338) |
| [`647a225bdc917c347a6aad50ff7be23c5e381127`](https://github.com/plebioda/percona-server-mongodb/commit/647a225bdc917c347a6aad50ff7be23c5e381127) | SERVER-127294 Fix race in NetworkInterfaceTest.NumRequestsTimedOutBeforeSentToRemoteMetric (#54215) |
| [`84ffb5f8ec365aa5959e6e0bcb4107b9b7a3802a`](https://github.com/plebioda/percona-server-mongodb/commit/84ffb5f8ec365aa5959e6e0bcb4107b9b7a3802a) | Revert "SERVER-127220 Ensure change stream topology v2 stage respects maxAwaitTimeMS in Waiting state (#54110)" (#54351) |
| [`7dbfe6f86f4c7095aecfe340888eeda3331bea0b`](https://github.com/plebioda/percona-server-mongodb/commit/7dbfe6f86f4c7095aecfe340888eeda3331bea0b) | SERVER-127357 Reject duplicate fields in $graphLookup createFromBson (#54230) |
| [`172e46ce050e7ba7faafd94108a3b559cc37c884`](https://github.com/plebioda/percona-server-mongodb/commit/172e46ce050e7ba7faafd94108a3b559cc37c884) | SERVER-127325 Enable UnrecoverableErrorDuringDonatingInitialData resharding donor test (#54330) |
| [`80c6c2419e3049cec79cf391c6b7b1e580a696d2`](https://github.com/plebioda/percona-server-mongodb/commit/80c6c2419e3049cec79cf391c6b7b1e580a696d2) | SERVER-126766 Fix missing lock on _totalNumBatchesProcessed and _last… (#54240) |
| [`d059c87f879ff3e06bc488058b3cfd316f23cf7c`](https://github.com/plebioda/percona-server-mongodb/commit/d059c87f879ff3e06bc488058b3cfd316f23cf7c) | SERVER-127293 Handle "cu" opType in _parseAreOpsCrudOnly (#54165) |
| [`0076cca5e1a9fbd4e54e2bc9f2469f74953edf34`](https://github.com/plebioda/percona-server-mongodb/commit/0076cca5e1a9fbd4e54e2bc9f2469f74953edf34) | SERVER-127122 Keep PCTE registry token alive until destruction completes (#54080) |
| [`922dc86d56ce393e15a19d337a37c982d0fa9a38`](https://github.com/plebioda/percona-server-mongodb/commit/922dc86d56ce393e15a19d337a37c982d0fa9a38) | SERVER-127421 Revert to jepsen v0.3.0 for ASC tests (#54328) |
| [`9b5e8058d10d7df3a618b5fab32af41f65b4814b`](https://github.com/plebioda/percona-server-mongodb/commit/9b5e8058d10d7df3a618b5fab32af41f65b4814b) | SERVER-127211 Field only depended on by dead fields should be considered dead (#54151) |
| [`8a1906026fb2152da4d1d9759e38cd63d464527b`](https://github.com/plebioda/percona-server-mongodb/commit/8a1906026fb2152da4d1d9759e38cd63d464527b) | SERVER-127361: Add bazel targets for replication resmoke suites (#54144) |
| [`7c646dc7cb46c38b8f5a5a35d0632ca48df4422c`](https://github.com/plebioda/percona-server-mongodb/commit/7c646dc7cb46c38b8f5a5a35d0632ca48df4422c) | SERVER-127283: Add bazel targets for cluster-scalability resmoke suites (#54140) |
| [`89da0f966aa4c3baac39f5ab93ab5a1dc40c622d`](https://github.com/plebioda/percona-server-mongodb/commit/89da0f966aa4c3baac39f5ab93ab5a1dc40c622d) | SERVER-124148 Remove replicated fast count failpoint from db_stats.js (#54259) |
| [`b0d52c74d75276b2cb4da3def43b0575b47bd3ec`](https://github.com/plebioda/percona-server-mongodb/commit/b0d52c74d75276b2cb4da3def43b0575b47bd3ec) | SERVER-121502 Fallback JOO if STP is rooted \$or (#54099) |
| [`0cc5ead7c1f5a97c7ef5b4d1a0b1f0daaa29b2f5`](https://github.com/plebioda/percona-server-mongodb/commit/0cc5ead7c1f5a97c7ef5b4d1a0b1f0daaa29b2f5) | SERVER-118423 Implement `DocsNeededBounds` reporting for extensions (#51217) |
| [`dfa15cc750ec0f0317b5844c77a5e5ed8c2dce2d`](https://github.com/plebioda/percona-server-mongodb/commit/dfa15cc750ec0f0317b5844c77a5e5ed8c2dce2d) | SERVER-119043: Add support for streamable replSetHeartbeat (#53490) |
| [`a82c185e068336eee6dce08f464823e9544b917b`](https://github.com/plebioda/percona-server-mongodb/commit/a82c185e068336eee6dce08f464823e9544b917b) | SERVER-124332. Populate sample metadata in explain output (#53931) |
| [`dcc12f9da8f98018d4e6bd4d523502d0f13c43f0`](https://github.com/plebioda/percona-server-mongodb/commit/dcc12f9da8f98018d4e6bd4d523502d0f13c43f0) | SERVER-127291: $iceberg dynamic routing for tableName (#54053) |
| [`25ad608487a43fe54bb779b3c5fc33bf09e6f34e`](https://github.com/plebioda/percona-server-mongodb/commit/25ad608487a43fe54bb779b3c5fc33bf09e6f34e) | SERVER-127220 Ensure change stream topology v2 stage respects maxAwaitTimeMS in Waiting state (#54110) |
| [`4a77f015407ee4c48ccc83664122c93af3184b57`](https://github.com/plebioda/percona-server-mongodb/commit/4a77f015407ee4c48ccc83664122c93af3184b57) | SERVER-127336 Add an optional UUID field to the schemas of config.shards and ShardIdentity doc (#54210) |
| [`0acdc226ba5abe85d8841d2277ebde819bc92d3e`](https://github.com/plebioda/percona-server-mongodb/commit/0acdc226ba5abe85d8841d2277ebde819bc92d3e) | SERVER-127044 Introduce new error code returned by blockReplicaSetWrites (#54097) |
| [`464a7f6c41e406b7cd93b77b5b8c912d8335e528`](https://github.com/plebioda/percona-server-mongodb/commit/464a7f6c41e406b7cd93b77b5b8c912d8335e528) | SERVER-123247 Implement QuerySettingsKnobOverrides hasher (#53643) |
| [`4c322596fc8985cec9cac9e92876fe335271d6fa`](https://github.com/plebioda/percona-server-mongodb/commit/4c322596fc8985cec9cac9e92876fe335271d6fa) | SERVER-110427 Update profiling data (#54309) |
| [`7e39b9cb03214c7e9da038a379603f7a6645877e`](https://github.com/plebioda/percona-server-mongodb/commit/7e39b9cb03214c7e9da038a379603f7a6645877e) | SERVER-123734 Add new metrics to track the new user write block (#52232) |
| [`ceec5e80e8b3aa19a7a50ffa342e471531313160`](https://github.com/plebioda/percona-server-mongodb/commit/ceec5e80e8b3aa19a7a50ffa342e471531313160) | SERVER-121814 Complete TODO listed in SERVER-107138 (#54011) |
| [`11d71e49c2ad22c48eb37f3e03926e59171f8d11`](https://github.com/plebioda/percona-server-mongodb/commit/11d71e49c2ad22c48eb37f3e03926e59171f8d11) | SERVER-126200 Remove chunkless references in the authoritative shard catalog (#54004) |
| [`231399c6e6129bd6ac4c0c565d829e1baf7925b6`](https://github.com/plebioda/percona-server-mongodb/commit/231399c6e6129bd6ac4c0c565d829e1baf7925b6) | SERVER-127275 Move recipient driven promises to ReshardingRecipientPromises (#54181) |
| [`6fcf68e2e101589cf41170b253bdcfdf875bd1e2`](https://github.com/plebioda/percona-server-mongodb/commit/6fcf68e2e101589cf41170b253bdcfdf875bd1e2) | SERVER-127396: Add a flag for disabling testing on enterprise-amazon-linux2023-arm64-all-feature-flags-rbe (#54295) |
| [`d72260097a1b31d05b035615a8288c839600b1bb`](https://github.com/plebioda/percona-server-mongodb/commit/d72260097a1b31d05b035615a8288c839600b1bb) | SERVER-126385 Make unit tests that exercise _writeStateToContainer write conflict retry (#53613) |
| [`1777dfc214937a2570459be5c7fcd379a3314122`](https://github.com/plebioda/percona-server-mongodb/commit/1777dfc214937a2570459be5c7fcd379a3314122) | SERVER-124178 Re-enable test coll stat checks with replicated fast count (#54081) |
| [`da0cdcec063802bba59843bb82c3ff7be4622985`](https://github.com/plebioda/percona-server-mongodb/commit/da0cdcec063802bba59843bb82c3ff7be4622985) | SERVER-126398: Populate replicaSetId in the DSC replica set config ba… (#53624) |
| [`eec0f3e9f46193fe669825d041b10c578fb88da8`](https://github.com/plebioda/percona-server-mongodb/commit/eec0f3e9f46193fe669825d041b10c578fb88da8) | SERVER-65418 Add hold-ticket fallback threshold and a random jitter for write conflict sleep (#52596) |
| [`80454d8779e5142b852b570b45025237c31f52ee`](https://github.com/plebioda/percona-server-mongodb/commit/80454d8779e5142b852b570b45025237c31f52ee) | SERVER-127114 Code cleanup in profiler auto-disable code (#54180) |
| [`5e7d20d493fb441529dedd52f0b1e21f2751a0ab`](https://github.com/plebioda/percona-server-mongodb/commit/5e7d20d493fb441529dedd52f0b1e21f2751a0ab) | SERVER-122317 e2e container integration for replicated fast count (#52458) |
| [`a2f9b9137293022e7d4c831f74d706bdf9927ec2`](https://github.com/plebioda/percona-server-mongodb/commit/a2f9b9137293022e7d4c831f74d706bdf9927ec2) | SERVER-111072 Auto-generated SBOM files [master] (#53916) |
| [`bdbd328b7dff2a5d8df4dc1f2dc7d46f927399f7`](https://github.com/plebioda/percona-server-mongodb/commit/bdbd328b7dff2a5d8df4dc1f2dc7d46f927399f7) | SERVER-127277: Address heartbeat handle leak on DSC (#54079) |
| [`831f326a19bd3228106a7b54230d5383ca840962`](https://github.com/plebioda/percona-server-mongodb/commit/831f326a19bd3228106a7b54230d5383ca840962) | SERVER-127339 Skip record if before `lastSpilledRecordId` in PDIB scan (#54220) |
| [`949f95046245b388bd4350950449874a09949398`](https://github.com/plebioda/percona-server-mongodb/commit/949f95046245b388bd4350950449874a09949398) | SERVER-127131: Add reason to InvalidBSONColumn errors (#54072) |
| [`86089a110e630052bbbf6f6b38f9a22d528e35e4`](https://github.com/plebioda/percona-server-mongodb/commit/86089a110e630052bbbf6f6b38f9a22d528e35e4) | SERVER-127284 Extend SorterChecksumCalculator to handle WCE (#54224) |
| [`7786bd72654ade6d1ef34e2d558ba976f2401427`](https://github.com/plebioda/percona-server-mongodb/commit/7786bd72654ade6d1ef34e2d558ba976f2401427) | SERVER-126799: Filter NaN from $percentile/$median window function inputs (#53849) |
| [`3e584f02f30c4f619bee33e1344bfc54dabaac84`](https://github.com/plebioda/percona-server-mongodb/commit/3e584f02f30c4f619bee33e1344bfc54dabaac84) | SERVER-127129 Remove query_expression dependency on WhereMatchExpression (#54141) |
| [`bac4b3272d8e47e41d0ab339fc4e97e63dd52c98`](https://github.com/plebioda/percona-server-mongodb/commit/bac4b3272d8e47e41d0ab339fc4e97e63dd52c98) | SERVER-126451 Test deleting entries from sorter table with a write conflict (#54159) |
| [`0722eba8f47d83537055c2c84cb87a76e649f985`](https://github.com/plebioda/percona-server-mongodb/commit/0722eba8f47d83537055c2c84cb87a76e649f985) | Revert "SERVER-126252 Create resharding participant cancel state with ChangeStreamsMonitor-aware token (#53468)" (#54172) |
| [`0e298d597deabe76d086acead03329ec0f695416`](https://github.com/plebioda/percona-server-mongodb/commit/0e298d597deabe76d086acead03329ec0f695416) | SERVER-127297: Remove bolt specific variants (#54164) |
| [`59c88643b696e96e080236b1408ecc20e3821fa4`](https://github.com/plebioda/percona-server-mongodb/commit/59c88643b696e96e080236b1408ecc20e3821fa4) | SERVER-126240 Improve unit testing for ConnectionPool cancellation, shutdown and metrics (#53561) |
| [`2b4b703432151bb76b93e3359b36118b6fee7a0e`](https://github.com/plebioda/percona-server-mongodb/commit/2b4b703432151bb76b93e3359b36118b6fee7a0e) | SERVER-127335 Add findAndModify microbenchmark (#54202) |
| [`1fd842a9bb6a71a4f632a2f28dcf8b7fbe0d692d`](https://github.com/plebioda/percona-server-mongodb/commit/1fd842a9bb6a71a4f632a2f28dcf8b7fbe0d692d) | SERVER-126800: Fix $arrayToObject reversed k/v validation in SBE (#53850) |
| [`aa63d84077ed7d8fb9d8ac54ca4ed939e634560a`](https://github.com/plebioda/percona-server-mongodb/commit/aa63d84077ed7d8fb9d8ac54ca4ed939e634560a) | SERVER-127338 Use `lastSpilledRecordId` for PDIB scan resume position (#54211) |
| [`2779423eb3c617984707ffe084f59b584efbff3d`](https://github.com/plebioda/percona-server-mongodb/commit/2779423eb3c617984707ffe084f59b584efbff3d) | SERVER-32422 remove class StringData forward declarations (#54124) |
| [`e32f3bc2b3fa959fb82be7f52502fc4619ec2ca2`](https://github.com/plebioda/percona-server-mongodb/commit/e32f3bc2b3fa959fb82be7f52502fc4619ec2ca2) | SERVER-126463 collection cloner function_ref memory bug (#54143) |
| [`45b22ebdc8993a5fcc8484756bfdf5a541cfa6e4`](https://github.com/plebioda/percona-server-mongodb/commit/45b22ebdc8993a5fcc8484756bfdf5a541cfa6e4) | SERVER-127288 Split up `MultiIndexBlock::_constructStateObject` (#54161) |
| [`edc5fa4a7014f5a1e1a481b7ce7f12ebb50e0019`](https://github.com/plebioda/percona-server-mongodb/commit/edc5fa4a7014f5a1e1a481b7ce7f12ebb50e0019) | SERVER-126153  unique_function c++20 updates (#53353) |
| [`f686b54e2be23786d7a4fdfb2be1260bbe5dc9fb`](https://github.com/plebioda/percona-server-mongodb/commit/f686b54e2be23786d7a4fdfb2be1260bbe5dc9fb) | SERVER-127260: Use passkey idiom instead of friending std functions (#54122) |
| [`8f1a18bdbd305d4890f7b62d4b7898ad676c15fb`](https://github.com/plebioda/percona-server-mongodb/commit/8f1a18bdbd305d4890f7b62d4b7898ad676c15fb) | SERVER-126239 Improve unit testing for ConnectionPool failure, expiry and drop (#53560) |
| [`84ce383729ef440a1a41fa484490d761b5c16c3c`](https://github.com/plebioda/percona-server-mongodb/commit/84ce383729ef440a1a41fa484490d761b5c16c3c) | SERVER-127319: always respect MONGO_VERSION_OVERRIDE (#54182) |
| [`f629b92a639754ab2c21bc7211b8567145ae84e8`](https://github.com/plebioda/percona-server-mongodb/commit/f629b92a639754ab2c21bc7211b8567145ae84e8) | SERVER-127252 Consolidate try/catch blocks in `MultiIndexBlock` (#54116) |
| [`1551887ae9f63f2e316b0f131f0a2ebb3f422d92`](https://github.com/plebioda/percona-server-mongodb/commit/1551887ae9f63f2e316b0f131f0a2ebb3f422d92) | SERVER-127347: Increase defaultFindReplicaSetHostTimeoutMS on mongos for san builds (#54044) |
| [`b0bcbc2c5aa72be0ebb6464b7e80c4d1c22f5ddf`](https://github.com/plebioda/percona-server-mongodb/commit/b0bcbc2c5aa72be0ebb6464b7e80c4d1c22f5ddf) | SERVER-127053 Prepare configsvr chunk opertion's commands to commit authoritatively (#54088) |
| [`88e77b91252dd61898a2bce4440c215111807606`](https://github.com/plebioda/percona-server-mongodb/commit/88e77b91252dd61898a2bce4440c215111807606) | SERVER-125057 Wait for sharding coordinator service recovery before acquiring ActiveMigrationsRegistry locks (#53488) |
| [`ebc3b252dc8495ec92120f498439c8af337504d9`](https://github.com/plebioda/percona-server-mongodb/commit/ebc3b252dc8495ec92120f498439c8af337504d9) | SERVER-127127 Account for extensions-on-views after IFR kickback (#54106) |
| [`f6c66c1a946d34c63d79df8370d4e4c3e26fe58e`](https://github.com/plebioda/percona-server-mongodb/commit/f6c66c1a946d34c63d79df8370d4e4c3e26fe58e) | SERVER-108947 Expand PBT model to test empty paths - second reapply (#52033) |
| [`333ce46dac7f9c46fb2eead3c8a00a271c99373f`](https://github.com/plebioda/percona-server-mongodb/commit/333ce46dac7f9c46fb2eead3c8a00a271c99373f) | SERVER-119085: Make networkCounters a function and duplicate some network counters into otel (#53511) |
| [`31bfafd041d528acab2199d1d79cb8a2b802afbb`](https://github.com/plebioda/percona-server-mongodb/commit/31bfafd041d528acab2199d1d79cb8a2b802afbb) | SERVER-127124: block-on-red, group level overrides for dta (#54065) |
| [`7f4c9c7b3683bbe5779938f5816d5febe33390c7`](https://github.com/plebioda/percona-server-mongodb/commit/7f4c9c7b3683bbe5779938f5816d5febe33390c7) | SERVER-126452 Filter out internal resharding collection when balancer is running in drop_database.js (#53664) |
| [`2b1df07a979d3b7b95391569335d4b3fd970f480`](https://github.com/plebioda/percona-server-mongodb/commit/2b1df07a979d3b7b95391569335d4b3fd970f480) | SERVER-100611: Estimate seeks required for IXSCAN [reapply] (#53934) |
| [`75388dc3c6f12e448bd5d85c95fb7685130dca0c`](https://github.com/plebioda/percona-server-mongodb/commit/75388dc3c6f12e448bd5d85c95fb7685130dca0c) | SERVER-124392 Ensure DurableOplogEntry::toBSON() and MutableOplogEntry::toBSON() consistency (#54007) |
| [`e3744e96e9cbead02792238f525c47dbdcf20ede`](https://github.com/plebioda/percona-server-mongodb/commit/e3744e96e9cbead02792238f525c47dbdcf20ede) | SERVER-126969 Choose only valid IndexProbe indexes (#54092) |
| [`2b19fcf070fec31a4a43af1713b0ebba4d80a991`](https://github.com/plebioda/percona-server-mongodb/commit/2b19fcf070fec31a4a43af1713b0ebba4d80a991) | SERVER-110427 Update profiling data (#54185) |
| [`ea0c77bbdd5b77dafefb2b68843690c02882d85f`](https://github.com/plebioda/percona-server-mongodb/commit/ea0c77bbdd5b77dafefb2b68843690c02882d85f) | SERVER-126387 Extend server_selector_test.cpp tests for Injector tag when configOnly disabled (#53597) |
| [`70bba57744dd545bff5fd7e6128e8a55300d3aea`](https://github.com/plebioda/percona-server-mongodb/commit/70bba57744dd545bff5fd7e6128e8a55300d3aea) | SERVER-124050 enable eager reaping test for all-feature-flags (#54112) |
| [`0adedd4f48d17bc64124c77acd3cbc42ed709dec`](https://github.com/plebioda/percona-server-mongodb/commit/0adedd4f48d17bc64124c77acd3cbc42ed709dec) | SERVER-122957 Fix the feature flag checks as it conflicted with the bulk rename and it used a new process (#54155) |
| [`1ba8dd0ddf744bc1d4a9e823f02280c547d91147`](https://github.com/plebioda/percona-server-mongodb/commit/1ba8dd0ddf744bc1d4a9e823f02280c547d91147) | SERVER-119393 Implement aliveness check (#53952) |
| [`daec0b9e752f6881245d154672a407eaa194b110`](https://github.com/plebioda/percona-server-mongodb/commit/daec0b9e752f6881245d154672a407eaa194b110) | SERVER-122385 Enable disabled tests due to 8.3 FCV upgrade (#52041) |

</details>



# Merge Description

## Summary

This merge brings in 75 commits from MongoDB upstream (650d9f458c5). The main conflict is in sbom.json where MongoDB added description and license information while Percona maintains its own CPE/PURL identifiers and website URL. The merge also includes modifications to audit.h (important Percona file), various BUILD.bazel files, error_codes.yml, and mongod_main.cpp.


## Auto-Merged Files

| File Path | Description |
|-----------|-------------|
| `sbom.json` | Conflict between Percona's CPE/PURL identifiers (percona:percona-server-mongodb) and MongoDB's additions (description, licenses array, updated tools version v1.7.973). Percona's identifiers and URL should be preserved while incorporating MongoDB's new description and license fields. |
| `src/mongo/base/error_codes.yml` | Auto-merged changes to error code definitions from upstream MongoDB. |
| `src/mongo/db/BUILD.bazel` | Auto-merged build configuration changes for the db module. |
| `src/mongo/db/index_builds/BUILD.bazel` | Auto-merged build configuration changes for index builds module. |
| `src/mongo/db/mongod_main.cpp` | Auto-merged changes to the main mongod entry point. |
| `src/mongo/db/pipeline/BUILD.bazel` | Auto-merged build configuration changes for the aggregation pipeline module. |


## Review Notes

1. CRITICAL: Verify sbom.json conflict resolution preserves Percona-specific CPE (cpe:2.3:a:percona:percona-server-mongodb), PURL (pkg:github/percona/percona-server-mongodb), and website URL (https://percona.com) while incorporating MongoDB's new description and license fields. 2. Review src/mongo/db/audit.h changes carefully as this is flagged as an important Percona-specific file. 3. The tools version update from v1.7.968 to v1.7.973 in sbom.json should be accepted from upstream.


<details>
<summary>Agent Stats</summary>


**Agent:** claude_cli (version 2.1.148 (Claude Code))



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| claude-haiku-4-5-20251001 | 503 | 14 |  |  |  |  |
| claude-opus-4-5 | 18 | 1151 |  |  |  |  |


</details>



# Conflict Context

- **Base Commit:** [`a198be080ded26b3f171443302ead6cca70a31c3`](https://github.com/plebioda/percona-server-mongodb/commit/a198be080ded26b3f171443302ead6cca70a31c3)
- **Ours Commit:** [`8c1f7806050aaca37493caee638c5fc616bf02e3`](https://github.com/plebioda/percona-server-mongodb/commit/8c1f7806050aaca37493caee638c5fc616bf02e3)
- **Theirs Commit:** [`650d9f458c5aeb3ec4f0ad960b77a566e3932b3f`](https://github.com/plebioda/percona-server-mongodb/commit/650d9f458c5aeb3ec4f0ad960b77a566e3932b3f)

## Conflicted Files

| Path | Conflict Type |
|------|---------------|
| `sbom.json` | both modified |


<details>
<summary>Conflict details</summary>

## Their Commits

| Path | Commit | Message |
|------|--------|---------|
| `sbom.json` | [`650d9f458c5aeb3ec4f0ad960b77a566e3932b3f`](https://github.com/plebioda/percona-server-mongodb/commit/650d9f458c5aeb3ec4f0ad960b77a566e3932b3f) | SERVER-111072 Auto-generated SBOM files [master] (#54314) |

</details>



# Solutions

## Solution 1
### Summary

Resolved sbom.json merge conflict by keeping Percona-specific identifiers (CPE, PURL, URL) while incorporating MongoDB's new description, licenses array, and updated tools version.

**By:** Agent (claude_cli v2.1.148 (Claude Code))

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `sbom.json` | Merged both sides: (1) Added MongoDB's new 'description' and 'licenses' fields while keeping Percona's CPE and PURL values; (2) Kept Percona's 'https://percona.com' URL while adding the 'tools' section with the newer version (v1.7.973) from upstream. |


### Unresolved Files

All conflicts have been resolved.


### Modified Files

No additional files were modified.


### Review Notes

The resolution preserves Percona branding in CPE/PURL identifiers and supplier URL, while accepting upstream's structural additions (description, licenses array) and tool version bump. The licenses array references MongoDB's licensing which is appropriate since PSMDB is based on MongoDB.


<details>
<summary>Agent Stats</summary>


**Agent:** claude_cli (version 2.1.148 (Claude Code))



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| claude-haiku-4-5-20251001 | 503 | 15 |  |  |  |  |
| claude-opus-4-5 | 58 | 3137 |  |  |  |  |


</details>



---

*note created with mergai 0.1.dev111+gc2eff4572.d20260220*
