### PR TITLE
Resolve semantic conflicts for merge 'a391837ffa9' into 'master'

### DIFF
--- a/src/mongo/db/pipeline/document_source_backup_cursor.cpp
+++ b/src/mongo/db/pipeline/document_source_backup_cursor.cpp
@@ -69,8 +69,8 @@ DocumentSourceBackupCursor::LiteParsed::parse(const NamespaceString& nss,
     return std::make_unique<DocumentSourceBackupCursor::LiteParsed>(spec);
 }
 
-const char* DocumentSourceBackupCursor::getSourceName() const {
-    return kStageName.data();
+StringData DocumentSourceBackupCursor::getSourceName() const {
+    return kStageName;
 }
 
 Value DocumentSourceBackupCursor::serialize(const SerializationOptions& opts) const {

--- a/src/mongo/db/pipeline/document_source_backup_cursor.h
+++ b/src/mongo/db/pipeline/document_source_backup_cursor.h
@@ -103,7 +103,7 @@ public:
 
     ~DocumentSourceBackupCursor() override;
 
-    const char* getSourceName() const override;
+    StringData getSourceName() const override;
 
     static const Id& id;
 

--- a/src/mongo/db/pipeline/document_source_backup_cursor_extend.cpp
+++ b/src/mongo/db/pipeline/document_source_backup_cursor_extend.cpp
@@ -66,8 +66,8 @@ DocumentSourceBackupCursorExtend::LiteParsed::parse(const NamespaceString& nss,
     return std::make_unique<DocumentSourceBackupCursorExtend::LiteParsed>(spec);
 }
 
-const char* DocumentSourceBackupCursorExtend::getSourceName() const {
-    return kStageName.data();
+StringData DocumentSourceBackupCursorExtend::getSourceName() const {
+    return kStageName;
 }
 
 Value DocumentSourceBackupCursorExtend::serialize(const SerializationOptions& opts) const {

--- a/src/mongo/db/pipeline/document_source_backup_cursor_extend.h
+++ b/src/mongo/db/pipeline/document_source_backup_cursor_extend.h
@@ -101,7 +101,7 @@ public:
 
     ~DocumentSourceBackupCursorExtend() override;
 
-    const char* getSourceName() const override;
+    StringData getSourceName() const override;
 
     static const Id& id;
 

--- a/src/mongo/db/pipeline/document_source_backup_file.cpp
+++ b/src/mongo/db/pipeline/document_source_backup_file.cpp
@@ -78,8 +78,8 @@ std::unique_ptr<DocumentSourceBackupFile::LiteParsed> DocumentSourceBackupFile::
     return std::make_unique<DocumentSourceBackupFile::LiteParsed>(spec);
 }
 
-const char* DocumentSourceBackupFile::getSourceName() const {
-    return kStageName.data();
+StringData DocumentSourceBackupFile::getSourceName() const {
+    return kStageName;
 }
 
 Value DocumentSourceBackupFile::serialize(const SerializationOptions& opts) const {

--- a/src/mongo/db/pipeline/document_source_backup_file.h
+++ b/src/mongo/db/pipeline/document_source_backup_file.h
@@ -103,7 +103,7 @@ public:
 
     ~DocumentSourceBackupFile() override;
 
-    const char* getSourceName() const override;
+    StringData getSourceName() const override;
 
     static const Id& id;
 

--- a/src/mongo/db/s/resharding/resharding_recipient_promises.cpp
+++ b/src/mongo/db/s/resharding/resharding_recipient_promises.cpp
@@ -37,6 +37,9 @@
 namespace mongo {
 
 namespace {
+// intentional clang-tidy error: cannot initialize 'int' with a string literal
+// (clang-diagnostic-error)
+int kInjectedError = "this is not an int";
 using Self = ReshardingRecipientPromises;
 using RecoverMethod = void (Self::*)(WithLock, const ReshardingRecipientDocument&);
 using RecoveryFn = ReshardingPromiseRegistry<ReshardingRecipientDocument>::RecoveryFn;

--- a/src/mongo/db/s/resharding/resharding_recipient_promises.cpp
+++ b/src/mongo/db/s/resharding/resharding_recipient_promises.cpp
@@ -37,7 +37,7 @@
 namespace mongo {
 
 namespace {
-   using Self = ReshardingRecipientPromises;
+using Self = ReshardingRecipientPromises;
 using RecoverMethod = void (Self::*)(WithLock, const ReshardingRecipientDocument&);
 using RecoveryFn = ReshardingPromiseRegistry<ReshardingRecipientDocument>::RecoveryFn;
 

--- a/src/mongo/db/s/resharding/resharding_recipient_promises.cpp
+++ b/src/mongo/db/s/resharding/resharding_recipient_promises.cpp
@@ -37,9 +37,6 @@
 namespace mongo {
 
 namespace {
-// intentional clang-tidy error: cannot initialize 'int' with a string literal
-// (clang-diagnostic-error)
-int kInjectedError = "this is not an int";
 using Self = ReshardingRecipientPromises;
 using RecoverMethod = void (Self::*)(WithLock, const ReshardingRecipientDocument&);
 using RecoveryFn = ReshardingPromiseRegistry<ReshardingRecipientDocument>::RecoveryFn;


### PR DESCRIPTION
# Merge Info

- **Target Branch:** `master`
- **Target Branch SHA:** [`5750b44e73b11673af8ca4bd90265843d85f8f9a`](https://github.com/plebioda/percona-server-mongodb/commit/5750b44e73b11673af8ca4bd90265843d85f8f9a)
- **Merge Commit:** [`a391837ffa9847b41cd0feaedea9803fbc0cbf53`](https://github.com/plebioda/percona-server-mongodb/commit/a391837ffa9847b41cd0feaedea9803fbc0cbf53)


# Merge Context

- **Number of merged commits:** 20
- **Auto-merged files:** 20


## Important Files Modified

- `src/mongo/db/repl/initial_sync/initial_syncer.cpp`

- `src/mongo/db/repl/initial_sync/initial_syncer.h`

- `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp`




## Auto-Merged Files


- `BUILD.bazel`

- `bazel/config/BUILD.bazel`

- `jstests/auth/lib/commands_lib.js`

- `jstests/core/catalog/views/views_all_commands.js`

- `jstests/libs/write_concern_all_commands.js`

- `jstests/replsets/all_commands_downgrading_to_upgraded.js`

- `jstests/replsets/db_reads_while_recovering_all_commands.js`

- `jstests/sharding/all_commands_direct_shard_connection_auth.js`

- `jstests/sharding/database_versioning_all_commands.js`

- `jstests/sharding/read_write_concern_defaults_application.js`

- `jstests/sharding/safe_secondary_reads_drop_recreate.js`

- `jstests/sharding/safe_secondary_reads_single_migration_suspend_range_deletion.js`

- `jstests/sharding/safe_secondary_reads_single_migration_waitForDelete.js`

- `src/mongo/db/BUILD.bazel`

- `src/mongo/db/auth/action_type.idl`

- `src/mongo/db/commands/BUILD.bazel`

- `src/mongo/db/pipeline/BUILD.bazel`

- `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp`

- `src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h`

- `src/mongo/shell/utils.js`



**Merged with strategy:** ort




<details>
<summary>Show details</summary>

| Commit | Summary |
|------------|---------|
| [`a391837ffa9847b41cd0feaedea9803fbc0cbf53`](https://github.com/plebioda/percona-server-mongodb/commit/a391837ffa9847b41cd0feaedea9803fbc0cbf53) | Revert "SERVER-118423 Implement `DocsNeededBounds` reporting for extensions (#51217)" (#54404) |
| [`0e7050d2b9684d7df362af39cefad394821cc3aa`](https://github.com/plebioda/percona-server-mongodb/commit/0e7050d2b9684d7df362af39cefad394821cc3aa) | SERVER-127058 StringData DocumentSource::getSourceName (#54016) |
| [`c9709d65c1a40375c7e19369ff0ada7bd1d80d92`](https://github.com/plebioda/percona-server-mongodb/commit/c9709d65c1a40375c7e19369ff0ada7bd1d80d92) | Revert "SERVER-124332. Populate sample metadata in explain output (#53931)" (#54399) |
| [`e4fc866a78abf7637e3537fca316fcf9297d1a54`](https://github.com/plebioda/percona-server-mongodb/commit/e4fc866a78abf7637e3537fca316fcf9297d1a54) | SERVER-127475: Remove featureFlagReplicatedFastCountDurability check in shouldUseReplicatedFastCountContainers (#54376) |
| [`4bd36565b9ae79cd4c2dd7de59f215a4f651bdd2`](https://github.com/plebioda/percona-server-mongodb/commit/4bd36565b9ae79cd4c2dd7de59f215a4f651bdd2) | SERVER-127414 DeferredToken::get() accounts for elapsed time before sleep (#54368) |
| [`a48dcebbc69aec2a3f4b32614be7e48604f17204`](https://github.com/plebioda/percona-server-mongodb/commit/a48dcebbc69aec2a3f4b32614be7e48604f17204) | SERVER-127040: Replace AutoGetCollection in index build tests with collection acquisitions (#53828) |
| [`63745eaa450b30322ff17ccf63d3d58893c796a7`](https://github.com/plebioda/percona-server-mongodb/commit/63745eaa450b30322ff17ccf63d3d58893c796a7) | SERVER-125965: Wait for stable timestamp to advance in initial sync (#54176) |
| [`7d1b18f756199542e6a41278043c8115d86815e2`](https://github.com/plebioda/percona-server-mongodb/commit/7d1b18f756199542e6a41278043c8115d86815e2) | SERVER-127367 Fix Evergreen timeout for tls_protocols.js Windows server 2022 (#54239) |
| [`862ad0e50b5a148383f86e008bdafa4ef2818303`](https://github.com/plebioda/percona-server-mongodb/commit/862ad0e50b5a148383f86e008bdafa4ef2818303) | SERVER-125598 Integrate ReshardingPromiseRegistry with donor state machine (#54098) |
| [`36e3e2ea23e2067aeb3da6380b80758acbebdd56`](https://github.com/plebioda/percona-server-mongodb/commit/36e3e2ea23e2067aeb3da6380b80758acbebdd56) | SERVER-127276 Move coordinator driven promises to ReshardingRecipientPromises (#54384) |
| [`88fbe993b7d572c3ff595c1bf8de95bb04e23be5`](https://github.com/plebioda/percona-server-mongodb/commit/88fbe993b7d572c3ff595c1bf8de95bb04e23be5) | SERVER-113557 Bolt binary before we split off symbols (#53518) |
| [`b7fbac8dd4d59a353895f61f93f226796f3421bd`](https://github.com/plebioda/percona-server-mongodb/commit/b7fbac8dd4d59a353895f61f93f226796f3421bd) | SERVER-126358: log `attr` in `assert(expr, msg, attr)` (#54299) |
| [`a509e05dc1aed37f0fb1d50c516e563eefa6562e`](https://github.com/plebioda/percona-server-mongodb/commit/a509e05dc1aed37f0fb1d50c516e563eefa6562e) | SERVER-122063 Attach metrics to insert response on shards for query stats (#53174) |
| [`53c3f3c5fb9115e6995b66efa686569ee10c0b3a`](https://github.com/plebioda/percona-server-mongodb/commit/53c3f3c5fb9115e6995b66efa686569ee10c0b3a) | SERVER-127012 Side write drains that are batched should use kGroupForTransactions (#54381) |
| [`c1fe003eeca2a2ad632fa13d0293061069658d23`](https://github.com/plebioda/percona-server-mongodb/commit/c1fe003eeca2a2ad632fa13d0293061069658d23) | SERVER-126324 Add stub implementation of updateESECMKIdentifierList command (#54111) |
| [`cd4d6770ed239ba4393dae802c48bd3dc3644301`](https://github.com/plebioda/percona-server-mongodb/commit/cd4d6770ed239ba4393dae802c48bd3dc3644301) | SERVER-125594 Implement desugaring infrastructure for hybrid search lite parsed stages (#52718) |
| [`3b3507cb34f8b588e8506a3db99c42f0bfb29293`](https://github.com/plebioda/percona-server-mongodb/commit/3b3507cb34f8b588e8506a3db99c42f0bfb29293) | SERVER-127435 Read from timestamps container directly in initializeMetadata (#54354) |
| [`460b5db2b9a40d1b3d875202322608dde5b4399a`](https://github.com/plebioda/percona-server-mongodb/commit/460b5db2b9a40d1b3d875202322608dde5b4399a) | SERVER-127342 PlanStage etc use StringData (#54212) |
| [`138419c76cb5fc08755443a8712b961227c96181`](https://github.com/plebioda/percona-server-mongodb/commit/138419c76cb5fc08755443a8712b961227c96181) | SERVER-126254 Fix fsyncLock leaves durableOpTime stuck behind lastWritten (#53504) |
| [`25e034e700d58aadc71af425a923e9b424ca37cc`](https://github.com/plebioda/percona-server-mongodb/commit/25e034e700d58aadc71af425a923e9b424ca37cc) | SERVER-123711 scan collection for non-compliant docs on constraint upgrade sharded (#53220) |

</details>



# Solutions

## Solution 1
### Summary

format auto-fix: 1 file changed

**By:** Unknown

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `src/mongo/db/s/resharding/resharding_recipient_promises.cpp` | changed by 'format' auto-fix |


### Unresolved Files

All conflicts have been resolved.


### Modified Files

No additional files were modified.


### Review Notes

No review notes provided.


## Solution 2
### Summary

Fixed return type mismatch in Percona-specific backup document sources caused by upstream API change where DocumentSource::getSourceName() now returns StringData instead of const char*.

**By:** Agent (claude_cli v2.1.159 (Claude Code))

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `src/mongo/db/pipeline/document_source_backup_cursor.h` | Changed getSourceName() return type from 'const char*' to 'StringData' to match the new base class signature |
| `src/mongo/db/pipeline/document_source_backup_cursor.cpp` | Changed getSourceName() return type to StringData and return kStageName directly instead of kStageName.data() |
| `src/mongo/db/pipeline/document_source_backup_cursor_extend.h` | Changed getSourceName() return type from 'const char*' to 'StringData' to match the new base class signature |
| `src/mongo/db/pipeline/document_source_backup_cursor_extend.cpp` | Changed getSourceName() return type to StringData and return kStageName directly instead of kStageName.data() |
| `src/mongo/db/pipeline/document_source_backup_file.h` | Changed getSourceName() return type from 'const char*' to 'StringData' to match the new base class signature |
| `src/mongo/db/pipeline/document_source_backup_file.cpp` | Changed getSourceName() return type to StringData and return kStageName directly instead of kStageName.data() |


### Unresolved Files

All conflicts have been resolved.


### Modified Files

No additional files were modified.


### Review Notes

Root cause: upstream commit changed DocumentSource::getSourceName() virtual method signature from 'const char*' to 'StringData' in document_source.h:311. Searched for all 'const char* getSourceName' patterns in the pipeline directory to find all affected sites - found exactly 3 Percona-specific document sources (backup_cursor, backup_cursor_extend, backup_file). All other document sources in the codebase already use StringData. Since kStageName is already a constexpr StringData in these files, the fix is straightforward: return it directly instead of calling .data().


<details>
<summary>Agent Stats</summary>


**Agent:** claude_cli (version 2.1.159 (Claude Code))



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| claude-haiku-4-5-20251001 | 523 | 16 |  |  |  |  |
| claude-opus-4-5 | 21 | 4370 |  |  |  |  |


</details>


## Solution 3
### Summary

Some manual fix

**By:** Pawel Lebioda <pawel.lebioda@percona.com>

### Resolved Files

No files were resolved.


### Unresolved Files

All conflicts have been resolved.


### Modified Files


- `src/mongo/db/s/resharding/resharding_recipient_promises.cpp`



### Review Notes

No review notes provided.


## Solution 4
### Summary

Removed intentionally injected error code from resharding_recipient_promises.cpp that was accidentally left in by a prior human 'manual fix' commit (bb73a368bc0). The injected code attempted to initialize an int with a string literal, causing build failure.

**By:** Agent (claude_cli v2.1.159 (Claude Code))

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `src/mongo/db/s/resharding/resharding_recipient_promises.cpp` | Removed 3 lines of intentionally broken test/debug code (comment and 'int kInjectedError = "this is not an int"') that was accidentally introduced in commit bb73a368bc0. Restored the file to match the upstream version from merge commit a391837ffa9. |


### Unresolved Files

All conflicts have been resolved.


### Modified Files

No additional files were modified.


### Review Notes

Root cause: A prior human 'manual fix' commit (bb73a368bc0, summary: 'Some manual fix') introduced intentional error injection code with the comment '// intentional clang-tidy error: cannot initialize int with a string literal'. This code appears to be test/debug code that should never have been committed. Verified by comparing with upstream merge commit a391837ffa9 which does not contain these lines. The fix simply removes the injected error to restore the file to its correct state.


<details>
<summary>Agent Stats</summary>


**Agent:** claude_cli (version 2.1.159 (Claude Code))



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| claude-haiku-4-5-20251001 | 523 | 15 |  |  |  |  |
| claude-opus-4-5 | 18 | 1875 |  |  |  |  |


</details>



---

*note created with mergai 0.1.dev111+gc2eff4572.d20260220*
