### PR TITLE
Resolve conflicts for merge 'e7742be8f80' into 'master'

### DIFF
--- a/buildscripts/sbom_linter.py
+++ b/buildscripts/sbom_linter.py
@@ -301,17 +301,7 @@ def main() -> int:
     # This is not a real third party, its just the local ssl pretending to be boringssl
     third_party_libs.discard("boringssl_replacement")
     # This is just a build file that gets inserted into a third party
-<<<<<<< HEAD
-    third_party_libs.remove("wasmtime")
-||||||| 19f73da3c88
-    third_party_libs.remove("wasmtime")
-    # Nothing in this directory is included in Community/EA
-    third_party_libs.remove("private")
-=======
     third_party_libs.discard("wasmtime")
-    # Nothing in this directory is included in Community/EA
-    third_party_libs.discard("private")
->>>>>>> e7742be8f804dad1aba73ce6a516e732e6050174
     error_manager = lint_sbom(input_file, output_file, third_party_libs, should_format)
     error_manager.print_errors()
 

--- a/sbom.json
+++ b/sbom.json
@@ -2,16 +2,8 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-<<<<<<< HEAD
   "serialNumber": "urn:uuid:95a559f1-b091-4a92-b80d-e6d37c5e477c",
-  "version": 5,
-||||||| 19f73da3c88
-  "serialNumber": "urn:uuid:2d7fbf85-c8b6-4f90-9966-70da88224a36",
-  "version": 5,
-=======
-  "serialNumber": "urn:uuid:2d7fbf85-c8b6-4f90-9966-70da88224a36",
   "version": 6,
->>>>>>> e7742be8f804dad1aba73ce6a516e732e6050174
   "metadata": {
     "timestamp": "2026-06-02T08:05:49Z",
     "lifecycles": [
@@ -68,20 +60,7 @@
     "supplier": {
       "name": "Percona LLC",
       "url": [
-<<<<<<< HEAD
         "https://percona.com"
-||||||| 19f73da3c88
-        "https://mongodb.com"
-      ]
-    },
-    "tools": {
-      "services": [
-        {
-          "name": "Endor Labs Inc",
-          "version": "v1.7.973"
-        }
-=======
-        "https://mongodb.com"
       ]
     },
     "tools": {
@@ -90,7 +69,6 @@
           "name": "Endor Labs Inc",
           "version": "v1.7.988"
         }
->>>>>>> e7742be8f804dad1aba73ce6a516e732e6050174
       ]
     }
   },


### PR DESCRIPTION
# Merge Info

- **Target Branch:** `master`
- **Target Branch SHA:** [`3d02afa7e1c0d00a4a4c848a61ffa7fa24cad903`](https://github.com/plebioda/percona-server-mongodb/commit/3d02afa7e1c0d00a4a4c848a61ffa7fa24cad903)
- **Merge Commit:** [`e7742be8f804dad1aba73ce6a516e732e6050174`](https://github.com/plebioda/percona-server-mongodb/commit/e7742be8f804dad1aba73ce6a516e732e6050174)


# Merge Context

- **Number of merged commits:** 52
- **Auto-merged files:** 12



## Auto-Merged Files


- `.bazelrc`

- `buildscripts/resmokelib/configure_resmoke.py`

- `buildscripts/sbom_linter.py`

- `jstests/auth/sasl_mechanism_discovery.js`

- `sbom.json`

- `src/mongo/db/BUILD.bazel`

- `src/mongo/db/index_builds/BUILD.bazel`

- `src/mongo/db/server_options_helpers.cpp`

- `src/mongo/shell/BUILD.bazel`

- `src/mongo/shell/servers.js`

- `src/third_party/wiredtiger/src/conn/conn_api.c`

- `src/third_party/wiredtiger/src/include/wiredtiger.h.in`



**Merged with strategy:** ort



<details>
<summary>Show details</summary>

| Commit | Summary |
|------------|---------|
| [`e7742be8f804dad1aba73ce6a516e732e6050174`](https://github.com/plebioda/percona-server-mongodb/commit/e7742be8f804dad1aba73ce6a516e732e6050174) | SERVER-111072 Auto-generated SBOM files [master] (#54708) |
| [`ba14edd81e33ea16728229382a6cbb7b5995e170`](https://github.com/plebioda/percona-server-mongodb/commit/ba14edd81e33ea16728229382a6cbb7b5995e170) | SERVER-127412 Update TypeChunk using ShardRef instead of ShardId (#54817) |
| [`cd83b5dda1d91f6bc4ec69869bdbca873f2d710e`](https://github.com/plebioda/percona-server-mongodb/commit/cd83b5dda1d91f6bc4ec69869bdbca873f2d710e) | SERVER-128110: Don't profile or optimize just built build tools (#54945) |
| [`a280fa65bfcd8dfce66d33de48577be9d1a884df`](https://github.com/plebioda/percona-server-mongodb/commit/a280fa65bfcd8dfce66d33de48577be9d1a884df) | SERVER-101878 Replace printjsononeline with jsTest.log.info in jstests (#53344) |
| [`f2c61a7552216a6e0218832acc6c7e2dd82dd3c6`](https://github.com/plebioda/percona-server-mongodb/commit/f2c61a7552216a6e0218832acc6c7e2dd82dd3c6) | SERVER-123714 add validationLevelTelemetry serverStatus section (#54363) |
| [`526a8e21d2b8e0054ad58661c76a9bf6ce2035be`](https://github.com/plebioda/percona-server-mongodb/commit/526a8e21d2b8e0054ad58661c76a9bf6ce2035be) | SERVER-124153 Re-enable sharding tests that fail if numRecords/dataSize is stale in replicated fast count suite (#54605) |
| [`32eb259e52a43a933ba9b0521249717fab8bf9fb`](https://github.com/plebioda/percona-server-mongodb/commit/32eb259e52a43a933ba9b0521249717fab8bf9fb) | SERVER-126456: Remove dead facilitynames table from server_options_helpers.cpp (#54329) |
| [`fc3a3ee67de202a78b54df45afe484a9e64ea2af`](https://github.com/plebioda/percona-server-mongodb/commit/fc3a3ee67de202a78b54df45afe484a9e64ea2af) | SERVER-127250 Add feature flag for CMK Rotation (#54934) |
| [`9497e66a4cb5e0f95921902e97d881ee8dd86730`](https://github.com/plebioda/percona-server-mongodb/commit/9497e66a4cb5e0f95921902e97d881ee8dd86730) | SERVER-125656 Bound geo parsing reason strings (#54744) |
| [`ad1789e6ef770f565e5e240037bf1e428eafd0e7`](https://github.com/plebioda/percona-server-mongodb/commit/ad1789e6ef770f565e5e240037bf1e428eafd0e7) | SERVER-127908 SERVER-127593: Enable featureFlagDSCLinearizableReadConcern (#54752) |
| [`fb571bb7aa91e73d6faaf15116de513cc0232cde`](https://github.com/plebioda/percona-server-mongodb/commit/fb571bb7aa91e73d6faaf15116de513cc0232cde) | SERVER-127522 Add test coverage for targeted replicated size and count tests (#54833) |
| [`98b2c3cb9eb74946aaa009d6b15225b456c0f62a`](https://github.com/plebioda/percona-server-mongodb/commit/98b2c3cb9eb74946aaa009d6b15225b456c0f62a) | SERVER-127320 Fix timeseries $geoWithin bucket filter producing empty bounding box from floating-point round-trip. (#54184) |
| [`c319a3c8d9d6b26d4dfb4f67da36d5f736087594`](https://github.com/plebioda/percona-server-mongodb/commit/c319a3c8d9d6b26d4dfb4f67da36d5f736087594) | SERVER-127923: Replace AutoGetCollection in repl tests with collection acquisitions (#53836) |
| [`a67fc9da67c965b141e16facbead66f21f091441`](https://github.com/plebioda/percona-server-mongodb/commit/a67fc9da67c965b141e16facbead66f21f091441) | SERVER-101276 Add invariant to detect shard key change on control.min.time (#50882) |
| [`2b4b4a809c6b11f1b0129f116fe207c6ad239ce6`](https://github.com/plebioda/percona-server-mongodb/commit/2b4b4a809c6b11f1b0129f116fe207c6ad239ce6) | SERVER-127439 Make DropIndexesCoordinator use the new setAllowMigrations (#54834) |
| [`c267576b64a1c005cb4975ebc8a26a5aefa05629`](https://github.com/plebioda/percona-server-mongodb/commit/c267576b64a1c005cb4975ebc8a26a5aefa05629) | SERVER-127853: preserve camel case in the name of a setter function (#54693) |
| [`c3cf1ae62420a6f9de4ae3cbb5de9e5ff705faaf`](https://github.com/plebioda/percona-server-mongodb/commit/c3cf1ae62420a6f9de4ae3cbb5de9e5ff705faaf) | SERVER-127799: Refactor otel tracing build rules (#54667) |
| [`efb50105cc3e6251bb3b881ab77d1cfcdd17e98c`](https://github.com/plebioda/percona-server-mongodb/commit/efb50105cc3e6251bb3b881ab77d1cfcdd17e98c) | SERVER-127767 Make temporary resharding collection creation authoritative (#54633) |
| [`890c7192111d73106ee3fc971d4b493cf28bb0e2`](https://github.com/plebioda/percona-server-mongodb/commit/890c7192111d73106ee3fc971d4b493cf28bb0e2) | SERVER-127544 Replace wildcard multikey side recovery unit with per-snapshot in-process cache (#54528) |
| [`12c0fe15dbad92051c6d91fc075511e1e4362983`](https://github.com/plebioda/percona-server-mongodb/commit/12c0fe15dbad92051c6d91fc075511e1e4362983) | SERVER-127680 Build more types of indexes in resumable PDIB testing (#54832) |
| [`1a20e0fc8f457678fef61ab184ad37c2f00ac5a1`](https://github.com/plebioda/percona-server-mongodb/commit/1a20e0fc8f457678fef61ab184ad37c2f00ac5a1) | SERVER-122074 Refactor `WriteCmdQueryStatsBatchRegistrar` to shapify delete commands on mongos (#54681) |
| [`69af9535d6ca4e45a5953caf6ea107d011e53010`](https://github.com/plebioda/percona-server-mongodb/commit/69af9535d6ca4e45a5953caf6ea107d011e53010) | SERVER-127880 use new jepsen linearizable tests for nightly runs to support DSC/ASC (#54717) |
| [`2975199f2259b56a2ce19dc0518aaede72037ceb`](https://github.com/plebioda/percona-server-mongodb/commit/2975199f2259b56a2ce19dc0518aaede72037ceb) | SERVER-127828 Batched ops using kGroupForAtomicWrite should update config.transactions (#54789) |
| [`6b0de5eca0b5abbe51d6a6c412b51334040c65f1`](https://github.com/plebioda/percona-server-mongodb/commit/6b0de5eca0b5abbe51d6a6c412b51334040c65f1) | SERVER-127929: Convert `metrics.ttl` into OTel metrics (#54780) |
| [`215c984fc01496f8dde55f8f333fc3fa2e5b2ab9`](https://github.com/plebioda/percona-server-mongodb/commit/215c984fc01496f8dde55f8f333fc3fa2e5b2ab9) | SERVER-127788 Fix mock OCSP responder hang on SIGINT under CPython (#54649) |
| [`06216ac2995c870634344e2a093b5a5638a0542c`](https://github.com/plebioda/percona-server-mongodb/commit/06216ac2995c870634344e2a093b5a5638a0542c) | SERVER-116154 Do not push $lookup to SBE if it would use a collscan and classic can use an index (#54178) |
| [`cf3d63f3b7364a4bb88d19fcdb33268b3c99f7fc`](https://github.com/plebioda/percona-server-mongodb/commit/cf3d63f3b7364a4bb88d19fcdb33268b3c99f7fc) | SERVER-127093 Avoid generating huge transactions in batch_size.js (#54897) |
| [`f4789c512c821953a0813ff532a381b3612b6645`](https://github.com/plebioda/percona-server-mongodb/commit/f4789c512c821953a0813ff532a381b3612b6645) | SERVER-36681 Handle non-existent dotted fields as null (#46641) |
| [`de829942be0e99a5ce126331733296705e36ba5d`](https://github.com/plebioda/percona-server-mongodb/commit/de829942be0e99a5ce126331733296705e36ba5d) | SERVER-128028: Fix stale-process misconnection in MongoRunner (#54865) |
| [`ca8e0f72899c281fce9c6542ffbc15dbfe1d27c7`](https://github.com/plebioda/percona-server-mongodb/commit/ca8e0f72899c281fce9c6542ffbc15dbfe1d27c7) | SERVER-119484 Do not assume previousVersion is only set during downgrade (#53492) |
| [`289a02c6e892fe3861ce0840a54322b8a3e51a3f`](https://github.com/plebioda/percona-server-mongodb/commit/289a02c6e892fe3861ce0840a54322b8a3e51a3f) | SERVER-126305 Mark mixed_version_replica_set.js incompatible on future git tag variants (#54023) |
| [`b9db9d2181de2431986ea10ccfffc6960fbf5e8b`](https://github.com/plebioda/percona-server-mongodb/commit/b9db9d2181de2431986ea10ccfffc6960fbf5e8b) | SERVER-128053 Tolerate QueryPlanKilled in multikey_timestamp_consistency (#54899) |
| [`f958a32362a0751e7b4291d07a64bbcb3251c05d`](https://github.com/plebioda/percona-server-mongodb/commit/f958a32362a0751e7b4291d07a64bbcb3251c05d) | SERVER-127441 Make RenameCollectionCoordinator use the new setAllowMigrations (#54835) |
| [`de2523be273b41e4af3eb9e24b16c203e38897bb`](https://github.com/plebioda/percona-server-mongodb/commit/de2523be273b41e4af3eb9e24b16c203e38897bb) | SERVER-128054 Fix stack-use-after-scope in `UpdateTimeseriesBucketingParamsDisablesFixedBucketing` (#54890) |
| [`35e82d122282908ec4afa6f48511f4eba5639b67`](https://github.com/plebioda/percona-server-mongodb/commit/35e82d122282908ec4afa6f48511f4eba5639b67) | SERVER-126811 Make timeseriesUpgradeDowngrade DDL commit to the shard catalog (#53864) |
| [`c0c2d5b1802b70133ea2c88cd0e37dc164352bde`](https://github.com/plebioda/percona-server-mongodb/commit/c0c2d5b1802b70133ea2c88cd0e37dc164352bde) | SERVER-117816 infer single table predicates from equi-join predicates (#51615) |
| [`f5bb057f4d18aa339b13b6bbf5a874b5d6a42ab6`](https://github.com/plebioda/percona-server-mongodb/commit/f5bb057f4d18aa339b13b6bbf5a874b5d6a42ab6) | Revert "SERVER-116054 Add support for $where (#53331)" (#54886) |
| [`d48cf0da5ee918c90de85a6b5b4768acc4fbf0ba`](https://github.com/plebioda/percona-server-mongodb/commit/d48cf0da5ee918c90de85a6b5b4768acc4fbf0ba) | SERVER-126821 Set fixedBucketing to false on bucketing parameter change (#54421) |
| [`e63f9964f00e940bf89cb009f658373616d78d36`](https://github.com/plebioda/percona-server-mongodb/commit/e63f9964f00e940bf89cb009f658373616d78d36) | SERVER-127407 Generate config server UUID when creating the shard identity (#54734) |
| [`07399bbc35a388d2fde347ecf7f54bac44f6cdb8`](https://github.com/plebioda/percona-server-mongodb/commit/07399bbc35a388d2fde347ecf7f54bac44f6cdb8) | Import wiredtiger: 028bf42c40ffc28498525ae87882b6c9308822c7 from branch mongodb-master (#54878) |
| [`74f7a66bed2238e8770439c0d267b10c1ac669ea`](https://github.com/plebioda/percona-server-mongodb/commit/74f7a66bed2238e8770439c0d267b10c1ac669ea) | SERVER-127933: Add OTel metrics for `indexBuilds` (#54786) |
| [`50f3d0b656c87556feeafbbc418636ea16570a4d`](https://github.com/plebioda/percona-server-mongodb/commit/50f3d0b656c87556feeafbbc418636ea16570a4d) | SERVER-127932: Add OTel metric for `indexStats.count` (#54785) |
| [`27f83d0a133864eca496d91e4f7daf34f0ec246c`](https://github.com/plebioda/percona-server-mongodb/commit/27f83d0a133864eca496d91e4f7daf34f0ec246c) | SERVER-122055 Collect query stats for deletes on standalone mongod (#54837) |
| [`66230eb1cf27c79920c805e5e613b9f08ace5b45`](https://github.com/plebioda/percona-server-mongodb/commit/66230eb1cf27c79920c805e5e613b9f08ace5b45) | SERVER-119013 Populate enabled mechanisms for UserNotFound (#54765) |
| [`17008793935273c670121ce4468365f17b55251e`](https://github.com/plebioda/percona-server-mongodb/commit/17008793935273c670121ce4468365f17b55251e) | SERVER-126907 Split up contents of index build table for PDIB (#54492) |
| [`bbde85f2ecf9173a96824a07b9f0f759eb7b4daf`](https://github.com/plebioda/percona-server-mongodb/commit/bbde85f2ecf9173a96824a07b9f0f759eb7b4daf) | SERVER-128004: Skip bazel resmoke test on s390x/ppc64le; mark resmoke … (#54847) |
| [`666abfe83f571985ab42a804856962c9e97eba1a`](https://github.com/plebioda/percona-server-mongodb/commit/666abfe83f571985ab42a804856962c9e97eba1a) | SERVER-127856 Check for 84k tag limit earlier in FLE2 insert or update processing (#54800) |
| [`f6c41929001a202e9f6f1d58c2212d9e91a747fb`](https://github.com/plebioda/percona-server-mongodb/commit/f6c41929001a202e9f6f1d58c2212d9e91a747fb) | SERVER-127777: Support hinting retry delay on retryable overload errors (#54678) |
| [`0e5c9b08c3a9aac2ebee0978317422f74d7122ee`](https://github.com/plebioda/percona-server-mongodb/commit/0e5c9b08c3a9aac2ebee0978317422f74d7122ee) | SERVER-121788 Integrate recipient CSM fetch   command in coordinator (#54219) |
| [`0352d73ca01ce8f44a8f1e0a262fce4682662eba`](https://github.com/plebioda/percona-server-mongodb/commit/0352d73ca01ce8f44a8f1e0a262fce4682662eba) | SERVER-127896: prevent kafka getting stuck when stopping and broker is unreachable (#54839) |
| [`0519be8a1a1b9ddff37ef032c25b23d4d33a2690`](https://github.com/plebioda/percona-server-mongodb/commit/0519be8a1a1b9ddff37ef032c25b23d4d33a2690) | SERVER-127024 Guard setParameter for internalQueryGlobalProfilingLockDeadlineMs on older nodes (#54539) |
| [`a85c85cf9da994fbfb007e1fdd7d6d701d8fa3c4`](https://github.com/plebioda/percona-server-mongodb/commit/a85c85cf9da994fbfb007e1fdd7d6d701d8fa3c4) | SERVER-124330 Enable analyze command 'sample' mode without testOnly registration (#54142) |

</details>


# Merge Description

## Summary

This merge brings upstream changes including: (1) SASL mechanism discovery behavior change where unknown users now receive the server's enabled mechanisms instead of undefined; (2) sbom_linter.py switches from set.remove() to set.discard() to avoid KeyError when items are missing; (3) sbom.json updates version to 6 and fixes googletest purl format; (4) Bazel build improvements including host feature flags for PGO/LTO and new subplanning_utils and error_labels_gen targets; (5) resmoke configure_resmoke.py adds $where pattern detection for mozjs-wasm exclusion; (6) shell servers.js adds PID verification to detect stale process connections; (7) WiredTiger key provider gains set_key callback and timestamp field for checkpoint encryption keys; (8) Solaris syslog facilitynames workaround removed from server_options_helpers.cpp.


## Auto-Merged Files

| File Path | Description |
|-----------|-------------|
| `.bazelrc` | Adds host feature flags to disable PGO profile generation/use, CSPGO profile generation/use, and thin LTO for built tools on Linux, avoiding unnecessary profiling/optimization overhead for host tools. |
| `buildscripts/resmokelib/configure_resmoke.py` | Adds '$where' pattern to _MOZJS_PATTERNS for mozjs-wasm unsupported feature detection (SERVER-116054). Updates TODO comment to reference both SERVER-116054 and SERVER-116052. Removes the else branch that was adding 'requires_mozjs_wasm' tag exclusion when not using mozjs-wasm. |
| `buildscripts/sbom_linter.py` | Changes all set.remove() calls to set.discard() for removing 'scripts', 'sasl', 'boringssl_replacement', 'wasmtime', and 'private' from third_party_libs. This prevents KeyError exceptions if items are not present in the set. |
| `jstests/auth/sasl_mechanism_discovery.js` | Changes expected behavior for unknown users: previously saslSupportedMechs was expected to be undefined for unknown users, now it should be an array containing the server's enabled mechanisms. Updates test assertion accordingly. |
| `sbom.json` | Increments version from 5 to 6, updates timestamp, updates Endor Labs version from v1.7.973 to v1.7.988, and fixes googletest purl/bom-ref format by removing 'v' prefix from version (v1.17.0 -> 1.17.0). |
| `src/mongo/db/BUILD.bazel` | Adds new subplanning_utils library target with sources from exec/classic. Adds error_labels_gen IDL generator. Adds otel_metrics_service dependency to server_status library. Adds server_parameter_test_util dependency to unit test target. |
| `src/mongo/db/index_builds/BUILD.bazel` | Adds otel_metrics_service dependency to the index builds library. |
| `src/mongo/db/server_options_helpers.cpp` | Removes Solaris compatibility code for syslog facilitynames. The removed code defined a CODE struct and facilitynames array when SYSLOG_NAMES was defined but INTERNAL_NOPRI was not (Solaris-specific workaround from SERVER-11160). |
| `src/mongo/shell/BUILD.bazel` | Changes types.js path from '//src/mongo/scripting/mozjs/common/jsfiles:types.js' to local 'types.js' in MONGOJS_CPP_JSFILES list. |
| `src/mongo/shell/servers.js` | Adds PID verification in MongoRunner.awaitConnection to detect connections to stale processes. After connecting, it checks serverStatus.pid matches the expected pid; if not, logs a warning about connecting to a stale process and throws MongoRunner.StopError with EXIT_NET_ERROR. |
| `src/third_party/wiredtiger/src/conn/conn_api.c` | When key provider version is 1, now also installs __wti_disagg_set_crypt_key as the set_key callback for the module to call. |
| `src/third_party/wiredtiger/src/include/wiredtiger.h.in` | Adds 'timestamp' field to WT_CRYPT_KEYS struct. Adds new set_key callback to WT_KEY_PROVIDER struct with documentation explaining it allows modules to provide encryption keys with associated timestamps for checkpoint writes. |


## Review Notes

Two files have conflicts requiring resolution: (1) buildscripts/sbom_linter.py - upstream changed remove() to discard(); fork previously removed the 'private' line; resolve by using discard() for all entries including wasmtime. (2) sbom.json - upstream incremented version and updated tool versions; fork has different serialNumber and percona.com URL; preserve fork's serialNumber and percona.com URL while taking upstream's version increment and tool updates.


<details>
<summary>Agent Stats</summary>


**Agent:** claude_cli (version 2.1.168 (Claude Code))



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| claude-haiku-4-5-20251001 | 503 | 14 |  |  |  |  |
| claude-opus-4-5 | 13 | 3345 |  |  |  |  |


</details>



# Conflict Context

- **Base Commit:** [`19f73da3c887a5505a83659789c7cfb03d5e9094`](https://github.com/plebioda/percona-server-mongodb/commit/19f73da3c887a5505a83659789c7cfb03d5e9094)
- **Ours Commit:** [`3d02afa7e1c0d00a4a4c848a61ffa7fa24cad903`](https://github.com/plebioda/percona-server-mongodb/commit/3d02afa7e1c0d00a4a4c848a61ffa7fa24cad903)
- **Theirs Commit:** [`e7742be8f804dad1aba73ce6a516e732e6050174`](https://github.com/plebioda/percona-server-mongodb/commit/e7742be8f804dad1aba73ce6a516e732e6050174)

## Conflicted Files

| Path | Conflict Type |
|------|---------------|
| `buildscripts/sbom_linter.py` | both modified |
| `sbom.json` | both modified |


<details>
<summary>Conflict details</summary>

## Their Commits

| Path | Commit | Message |
|------|--------|---------|
| `buildscripts/sbom_linter.py` | [`e7742be8f804dad1aba73ce6a516e732e6050174`](https://github.com/plebioda/percona-server-mongodb/commit/e7742be8f804dad1aba73ce6a516e732e6050174) | SERVER-111072 Auto-generated SBOM files [master] (#54708) |
| `sbom.json` | [`e7742be8f804dad1aba73ce6a516e732e6050174`](https://github.com/plebioda/percona-server-mongodb/commit/e7742be8f804dad1aba73ce6a516e732e6050174) | SERVER-111072 Auto-generated SBOM files [master] (#54708) |

</details>



# Solutions

## Solution 1
### Summary

Resolved merge conflicts in buildscripts/sbom_linter.py and sbom.json by adopting MongoDB's safer discard() method while keeping Percona-specific changes (removing 'private' directory handling, Percona UUID, Percona supplier URL)

**By:** Agent (claude_cli v2.1.168 (Claude Code))

### Resolved Files


| File Path | Resolution |
|-----------|------------|
| `buildscripts/sbom_linter.py` | Changed remove() to discard() for 'wasmtime' (safer method from theirs), kept Percona's change of not including the 'private' directory removal since Percona doesn't have that directory |
| `sbom.json` | Kept Percona's serialNumber UUID, updated version to 6 (from theirs), kept Percona's supplier URL (https://percona.com), added tools section with updated Endor Labs version v1.7.988 from theirs |


### Unresolved Files

All conflicts have been resolved.


### Modified Files

No additional files were modified.


### Review Notes

The sbom_linter.py change uses discard() instead of remove() which is safer as it won't raise KeyError if the item doesn't exist. The 'private' directory handling was removed in Percona's version - this is intentional as Percona doesn't have this directory. In sbom.json, Percona-specific metadata (serialNumber, supplier URL) is preserved while taking the newer version number and tool version from MongoDB upstream.


<details>
<summary>Agent Stats</summary>


**Agent:** claude_cli (version 2.1.168 (Claude Code))



| Model | Input | Output | Cached | Thoughts | Tool | Total |
|-------|-------|--------|--------|----------|------|-------|
| claude-haiku-4-5-20251001 | 503 | 14 |  |  |  |  |
| claude-opus-4-5 | 14 | 2584 |  |  |  |  |


</details>



---

*note created with mergai 0.1.dev111+gc2eff4572.d20260220*
